### PR TITLE
Do not require Webmock in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem "poltergeist"
   gem "shoulda-matchers", require: false
   gem "simplecov", require: false
-  gem "webmock"
+  gem "webmock", require: false
 end
 
 group :production do


### PR DESCRIPTION
Webmock RSpec is required in the `spec_helper` for ease of configuration. This makes it available to tests that require `rails_helper` and to tests that require `spec_helper`, since the latter is always required through `.rspec`.