### PR TITLE
Update reference to example .env file in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Defence Solicitor Service Rota
 
 ## Environment Variables
-see .env.example
+See `.example.env`. Add any new Env vars required to this file, setting
+placeholder data for them.


### PR DESCRIPTION
Correctly reference example env file.

Also, setting the file name to `.example.env` stops it being loaded by Dotenv.
This also adds information regarding maintenance of the file.