### PR TITLE
Setup Code Climate test coverage integration

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,3 @@
-unless ENV["NO_COVERAGE"]
-  require "simplecov"
-  SimpleCov.start "rails"
-end
-
 ENV["RAILS_ENV"] ||= "test"
 
 require File.expand_path("../../config/environment", __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,22 @@
+unless ENV["NO_COVERAGE"]
+  require "simplecov"
+  SimpleCov.start "rails"
+
+  if ENV["CODECLIMATE_REPO_TOKEN"]
+    require "codeclimate-test-reporter"
+    CodeClimate::TestReporter.start
+  end
+
+  SimpleCov.start "rails" do
+    if defined?(CodeClimate)
+      formatter SimpleCov::Formatter::MultiFormatter[
+        SimpleCov::Formatter::HTMLFormatter,
+        CodeClimate::TestReporter::Formatter
+      ]
+    end
+  end
+end
+
 require "webmock/rspec"
 
 RSpec.configure do |config|
@@ -15,4 +34,4 @@ RSpec.configure do |config|
   config.order = :random
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: "codeclimate.com")


### PR DESCRIPTION
This also moves the coverage setup into `spec/spec_helper` to ensure
coverage of specs not using `spec/rails_helper`.