### PR TITLE
Update FakeDataApi to reflect amended auth endpoints

### DIFF
--- a/app/models/fake_data_api.rb
+++ b/app/models/fake_data_api.rb
@@ -1,58 +1,68 @@
 class FakeDataApi
   def solicitors
-    solicitors_endpoint[:profiles]
+    solicitors_endpoint["profiles"]
   end
 
   def organisations
-    organisations_endpoint[:organisations]
+    organisations_endpoint["organisations"]
   end
 
   private
 
   def solicitors_endpoint
     {
-      "profiles": [
+      "profiles" => [
         {
-          "id": 1,
-          "name": "Bob Smith",
-          "type": "solicitor"
+          "uid" => "1a2b3c",
+          "name" => "Bob Smith",
+          "type" => "solicitor",
+          "links" => {
+            "organisation" => "/api/v1/organisations/1234567890abcdef"
+          }
         },
         {
-          "id": 2,
-          "name": "Andy Brown",
-          "type": "agent"
+          "uid" => "4d5e6f",
+          "name" => "Andy Brown",
+          "type" => "agent",
+          "links" => {
+            "organisation" => "/api/v1/organisations/2345678901bcdefa"
+          }
         }
       ],
-      "links": {
-        "first": "/api/v1/profiles",
-        "previous": "/api/v1/profiles?page=1",
-        "next": "/api/v1/profiles?page=2",
-        "last": "/api/v1/profiles?page=3"
+      "links" => {
+        "first" => "/api/v1/profiles",
+        "previous" => "/api/v1/profiles?page=1",
+        "next" => "/api/v1/profiles?page=2",
+        "last" => "/api/v1/profiles?page=3"
       }
     }
   end
 
   def organisations_endpoint
     {
-      "organisations": [
+      "organisations" => [
         {
-          "id": 1,
-          "name": "Tuckers",
-          "type": "law_firm",
-          "profile_ids": [1,2,3,5,6,7]
+          "uid" => "1234567890abcdef",
+          "name" => "Tuckers",
+          "type" => "law_firm",
+          "links" => {
+            "profiles" => "/api/v1/profiles?uids[]=1a2b3c&uids[]=4d5e6f&uids[]=a1b2c3"
+          }
         },
         {
-          "id": 2,
-          "name": "Brighton",
-          "type": "custody_suite",
-          "profile_ids": [5,8,9]
+          "uid" => "0987654321fedcba",
+          "name" => "Brighton",
+          "type" => "custody_suite",
+          "links" => {
+            "profiles" => "/api/v1/profiles?uids[]=0f9e8d&uids[]=7c6b5a"
+          }
         }
       ],
-      "links": {
-        "first": "/api/v1/organisations",
-        "previous": "/api/v1/organisations?page=1",
-        "next": "/api/v1/organisations?page=2",
-        "last": "/api/v1/organisations?page=3"
+      "links" => {
+        "first" => "/api/v1/organisations",
+        "previous" => "/api/v1/organisations?page=1",
+        "next" => "/api/v1/organisations?page=2",
+        "last" => "/api/v1/organisations?page=3"
       }
     }
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,13 +7,13 @@ class Organisation < APIModel
     new(attrs)
   end
 
-  attr_reader :id, :name, :type, :profile_ids
+  attr_reader :uid, :name, :type, :profiles_link
 
   def initialize(attrs)
-    @id = attrs.fetch(:id)
-    @name = attrs.fetch(:name)
-    @type = attrs.fetch(:type)
-    @profile_ids = attrs.fetch(:profile_ids)
+    @uid = attrs.fetch("uid")
+    @name = attrs.fetch("name")
+    @type = attrs.fetch("type")
+    @profiles_link = attrs.fetch("links").fetch("profiles")
   end
 
   def to_partial_path

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -7,12 +7,13 @@ class Solicitor < APIModel
     new(attrs)
   end
 
-  attr_reader :id, :name, :type
+  attr_reader :uid, :name, :type, :organisation_link
 
   def initialize(attrs)
-    @id = attrs.fetch(:id)
-    @name = attrs.fetch(:name)
-    @type = attrs.fetch(:type)
+    @uid = attrs.fetch("uid")
+    @name = attrs.fetch("name")
+    @type = attrs.fetch("type")
+    @organisation_link = attrs.fetch("links").fetch("organisation")
   end
 
   def to_partial_path

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -7,16 +7,20 @@ RSpec.describe Organisation, ".all" do
   it "creates organisation objects from the API response" do
     fake_response = [
       {
-        "id": 1,
-        "name": "Tuckers",
-        "type": "law_firm",
-        "profile_ids": [1,2,3,5,6,7]
+        "uid" => "1234567890abcdef",
+        "name" => "Tuckers",
+        "type" => "law_firm",
+        "links" => {
+          "profiles" => "/api/v1/profiles?uids[]=1a2b3c&uids[]=4d5e6f&uids[]=a1b2c3"
+        }
       },
       {
-        "id": 2,
-        "name": "Brighton",
-        "type": "custody_suite",
-        "profile_ids": [5,8,9]
+        "uid" => "0987654321fedcba",
+        "name" => "Brighton",
+        "type" => "custody_suite",
+        "links" => {
+          "profiles" => "/api/v1/profiles?uids[]=0f9e8d&uids[]=7c6b5a"
+        }
       }
     ]
 
@@ -33,17 +37,19 @@ end
 RSpec.describe Organisation, ".build_from" do
   it "builds an organisation object from passed-in attributes" do
     attrs = {
-      "id": 1,
-      "name": "Tuckers",
-      "type": "law_firm",
-      "profile_ids": [1, 2, 3, 5, 6, 7]
+      "uid" => "1234567890abcdef",
+      "name" => "Tuckers",
+      "type" => "law_firm",
+      "links" => {
+        "profiles" => "/api/v1/profiles?uids[]=1a2b3c&uids[]=4d5e6f&uids[]=a1b2c3"
+      }
     }
 
     organisation = Organisation.build_from attrs
 
-    expect(organisation.id).to eq 1
+    expect(organisation.uid).to eq "1234567890abcdef"
     expect(organisation.name).to eq "Tuckers"
     expect(organisation.type).to eq "law_firm"
-    expect(organisation.profile_ids).to eq [1, 2, 3, 5, 6, 7]
+    expect(organisation.profiles_link).to eq "/api/v1/profiles?uids[]=1a2b3c&uids[]=4d5e6f&uids[]=a1b2c3"
   end
 end

--- a/spec/models/solicitor_spec.rb
+++ b/spec/models/solicitor_spec.rb
@@ -7,14 +7,20 @@ RSpec.describe Solicitor, ".all" do
   it "creates solicitor objects from the API response" do
     fake_response = [
       {
-        "id": 1,
-        "name": "Bob Smith",
-        "type": "solicitor"
+        "uid" => "1a2b3c",
+        "name" => "Bob Smith",
+        "type" => "solicitor",
+        "links" => {
+          "organisation" => "/api/v1/organisations/1234567890abcdef"
+        }
       },
       {
-        "id": 2,
-        "name": "Andy Brown",
-        "type": "agent"
+        "uid" => "4d5e6f",
+        "name" => "Andy Brown",
+        "type" => "agent",
+        "links" => {
+          "organisation" => "/api/v1/organisations/2345678901bcdefa"
+        }
       }
     ]
 
@@ -31,15 +37,19 @@ end
 RSpec.describe Solicitor, ".build_from" do
   it "builds a solicitor object from passed-in attributes" do
     attrs = {
-          "id": 1,
-          "name": "Bob Smith",
-          "type": "solicitor"
-        }
+      "uid" => "1a2b3c",
+      "name" => "Bob Smith",
+      "type" => "solicitor",
+      "links" => {
+        "organisation" => "/api/v1/organisations/1234567890abcdef"
+      }
+    }
 
     solicitor = Solicitor.build_from attrs
 
-    expect(solicitor.id).to eq 1
+    expect(solicitor.uid).to eq "1a2b3c"
     expect(solicitor.name).to eq "Bob Smith"
     expect(solicitor.type).to eq "solicitor"
+    expect(solicitor.organisation_link).to eq "/api/v1/organisations/1234567890abcdef"
   end
 end


### PR DESCRIPTION
* Amended the `FakeDataApi` to use links and UIDs rather than IDs in response
* Use string keys to more accurately reflect the output from `JSON.parse` in a real API context