### PR TITLE
Auth failure route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,9 @@ gem "govuk_frontend_toolkit", "~> 2.0.1"
 gem "govuk_elements_rails", "~> 0.1.1"
 
 gem "omniauth-oauth2"
-gem "omniauth-dsds", github: "ministryofjustice/defence-request-service-omniauth-dsds", tag: "v0.6.2"
+gem "omniauth-dsds", github: "ministryofjustice/defence-request-service-omniauth-dsds", tag: "v0.7.0"
 gem "drs-auth_client", github: "ministryofjustice/defence-request-service-auth"
+
 
 group :development do
   gem "web-console", "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem "omniauth-oauth2"
 gem "omniauth-dsds", github: "ministryofjustice/defence-request-service-omniauth-dsds", tag: "v0.7.0"
 gem "drs-auth_client", github: "ministryofjustice/defence-request-service-auth"
 
-
 group :development do
   gem "web-console", "~> 2.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "govuk_frontend_toolkit", "~> 2.0.1"
 gem "govuk_elements_rails", "~> 0.1.1"
 
 gem "omniauth-oauth2"
-gem "omniauth-dsds", github: "ministryofjustice/defence-request-service-omniauth-dsds", tag: "v0.7.0"
+gem "omniauth-dsds", github: "ministryofjustice/defence-request-service-omniauth-dsds", tag: "v0.7.1"
 gem "drs-auth_client", github: "ministryofjustice/defence-request-service-auth"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: git://github.com/ministryofjustice/defence-request-service-omniauth-dsds.git
-  revision: 214948fda896f2962505456874fd79f3986fc561
-  tag: v0.6.2
+  revision: 6b05ea393781d72eee795a8e3ced6a0cd6056170
+  tag: v0.7.0
   specs:
-    omniauth-dsds (0.6.2)
+    omniauth-dsds (0.7.0)
       multi_json (~> 1.11.0)
       omniauth-oauth2 (~> 1.2.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: git://github.com/ministryofjustice/defence-request-service-omniauth-dsds.git
-  revision: 6b05ea393781d72eee795a8e3ced6a0cd6056170
-  tag: v0.7.0
+  revision: 21b99f498a1b0e77eeb096e040e2762cacd57531
+  tag: v0.7.1
   specs:
-    omniauth-dsds (0.7.0)
+    omniauth-dsds (0.7.1)
       multi_json (~> 1.11.0)
       omniauth-oauth2 (~> 1.2.0)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:create]
+  skip_before_action :authenticate_user!, only: [:create, :failure]
 
   def create
     session[:user_token] = auth_hash.fetch(:credentials).fetch(:token)

--- a/app/views/sessions/failure.html.erb
+++ b/app/views/sessions/failure.html.erb
@@ -1,0 +1,2 @@
+<h1>Unauthorized</h1>
+<p>You do not have access to this application.</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,3 +39,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end
+
+OmniAuth.config.on_failure = Proc.new { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
 
   get "/dashboard", to: "dashboards#show", as: :dashboard
   get "/auth/:provider/callback", to: "sessions#create"
+  get "/auth/failure", to: "sessions#failure"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :admin_user, class: Omniauth::Dsds::User do
+    roles ["admin"]
+
     to_create { |instance| instance }
 
     initialize_with {
@@ -7,7 +9,7 @@ FactoryGirl.define do
         uid: SecureRandom.uuid,
         name: "Example User",
         email: "user@example.com",
-        roles: ["admin"],
+        roles: roles,
         organisation_uids: []
       )
     }

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -7,4 +7,11 @@ RSpec.feature "User signs in" do
 
     expect(current_path).to eq "/dashboard"
   end
+
+  scenario "with no roles for Rota app gets redirected to auth failure page" do
+    admin_user = create :admin_user, roles: []
+    unauthorized_login_with admin_user
+
+    expect(current_path).to eq "/auth/failure"
+  end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -5,6 +5,21 @@ module SessionHelpers
 
   def login_with(user)
     mock_token
+    stub_current_user_with user
+
+    sign_in_using_dsds_auth
+  end
+
+  def unauthorized_login_with(user)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:defence_request] = :invalid_credentials
+
+    stub_current_user_with user
+
+    sign_in_using_dsds_auth
+  end
+
+  def stub_current_user_with(user)
     mock_profile(
       options: {
         uid: user.uid,
@@ -14,8 +29,6 @@ module SessionHelpers
         organisation_uids: user.organisation_uids
       }
     )
-
-    sign_in_using_dsds_auth
   end
 
   def sign_in_using_dsds_auth


### PR DESCRIPTION
Updates omniauth-dsds gem to the version that checks a users roles when logging in

Implements a public failure route thats users see when accessing the rota when they have no roles in the rota app.
Uses the omniauth default for failure route ```/auth/failure```

Depends on omniauth-dsds gem checking that current_user has roles for the application as a dependency: https://github.com/ministryofjustice/defence-request-service-omniauth-dsds/compare/v0.6.2...master