### PR TITLE
Remove members from a procurement area

### DIFF
--- a/app/controllers/procurement_area_memberships_controller.rb
+++ b/app/controllers/procurement_area_memberships_controller.rb
@@ -20,6 +20,18 @@ class ProcurementAreaMembershipsController < ApplicationController
     end
   end
 
+  def destroy
+    @procurement_area_membership = ProcurementAreaMembership.new(
+      procurement_area,
+      [],
+      { uid: params[:membership_uid] }
+    )
+
+    @procurement_area_membership.destroy
+
+    redirect_to procurement_area_path(procurement_area)
+  end
+
   private
 
   def procurement_area

--- a/app/models/procurement_area.rb
+++ b/app/models/procurement_area.rb
@@ -4,4 +4,12 @@ class ProcurementArea < ActiveRecord::Base
   def self.ordered_by_name
     order(name: :asc)
   end
+
+  def destroy_membership!(member_uid)
+    memberships.reject! do |member|
+      member["uid"] == member_uid
+    end
+
+    save!
+  end
 end

--- a/app/models/procurement_area_membership.rb
+++ b/app/models/procurement_area_membership.rb
@@ -20,10 +20,14 @@ class ProcurementAreaMembership
   def save
     if valid?
       add_membership_to_procurement_area
-      save_procurement_area
+      save_procurement_area!
     else
       false
     end
+  end
+
+  def destroy
+    procurement_area.destroy_membership!(membership_params[:uid])
   end
 
   private
@@ -61,7 +65,7 @@ class ProcurementAreaMembership
     )
   end
 
-  def save_procurement_area
+  def save_procurement_area!
     procurement_area.save!
   end
 end

--- a/app/views/procurement_areas/show.html.erb
+++ b/app/views/procurement_areas/show.html.erb
@@ -13,7 +13,7 @@
 
     <ul>
     <% @procurement_area.memberships.each do |membership| %>
-      <li><%= membership.name %></li>
+      <li><%= membership.name %> - <%= link_to "Delete member", procurement_area_membership_path(procurement_area_id: @procurement_area.id, membership_uid: membership.uid), method: :delete, data: { confirm: "Are you sure?" } %> </li>
     <% end %>
     </ul>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   resources :procurement_areas
   resources :procurement_area_locations, only: [:new, :create]
-  resources :procurement_area_memberships, only: [:new, :create]
+  resources :procurement_area_memberships, only: [:new, :create, :destroy]
 
   get "/dashboard", to: "dashboards#show", as: :dashboard
   get "/auth/:provider/callback", to: "sessions#create"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,5 +17,9 @@ FactoryGirl.define do
 
   factory :procurement_area do
     name "Outlands"
+
+    trait :with_members do
+      memberships { [] }
+    end
   end
 end

--- a/spec/features/user_manages_procurement_areas_spec.rb
+++ b/spec/features/user_manages_procurement_areas_spec.rb
@@ -69,6 +69,27 @@ RSpec.feature "User manages procurement areas" do
     expect(page).to have_content "Guilded Groom & Groom"
   end
 
+  scenario "removing a law firm membership from a procurement area" do
+    membership = {
+      name: "Guilded Groom & Groom",
+      uid: "1234567890abcdef"
+    }
+    admin_user = create :admin_user
+    create :procurement_area, :with_members, name: "The Dig", memberships: [
+      {
+        uid: membership[:uid],
+        type: "law_firm"
+      }
+    ]
+
+    login_with admin_user
+    click_link "Procurement areas"
+    click_link "View"
+    click_link "Delete member"
+
+    expect(page).not_to have_content "Guilded Groom & Groom"
+  end
+
   scenario "associating a location with a procurement area" do
     set_data_api_to FakeDataApis::FakeLocationsApi
 

--- a/spec/models/procurement_area_membership_spec.rb
+++ b/spec/models/procurement_area_membership_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe ProcurementAreaMembership, "#save" do
   end
 end
 
+RSpec.describe ProcurementAreaMembership, "#destroy" do
+  it "removes the provided member from the procurement area memberships" do
+    procurement_area = spy(:procurement_area)
+    organisations = []
+    membership_params = { uid: "abc123" }
+
+    ProcurementAreaMembership.new(procurement_area, organisations, membership_params).destroy
+
+    expect(procurement_area).to have_received(:destroy_membership!).with("abc123")
+  end
+end
+
 RSpec.describe ProcurementAreaMembership, "#eligible_organisations" do
   it "returns only organisations eligible to add as members" do
     existing_membership = { uid: "123", type: "existing example" }

--- a/spec/models/procurement_area_spec.rb
+++ b/spec/models/procurement_area_spec.rb
@@ -18,3 +18,18 @@ RSpec.describe ProcurementArea, ".ordered_by_name" do
       to eq ["Ankh-Morpork", "Be-Morpork", "Ce-Morpork"]
   end
 end
+
+RSpec.describe ProcurementArea, "#destroy_membership!" do
+  it "removes the membership with the given member uid" do
+    area = create(:procurement_area, memberships: [
+      {
+        uid: "abc123",
+        type: "law_firm"
+      }
+    ])
+
+    area.destroy_membership!("abc123")
+
+    expect(area.memberships).to be_blank
+  end
+end


### PR DESCRIPTION
* Creates a new `ProcurementAreaMembership` object, whose `destroy` method delegates back to the `ProcurementArea` for deletion.