### PR TITLE
Remove locations from a procurement area

### DIFF
--- a/app/controllers/procurement_area_locations_controller.rb
+++ b/app/controllers/procurement_area_locations_controller.rb
@@ -20,6 +20,18 @@ class ProcurementAreaLocationsController < ApplicationController
     end
   end
 
+  def destroy
+    @procurement_area_location = ProcurementAreaLocation.new(
+      procurement_area,
+      [],
+      { uid: params[:location_uid] }
+    )
+
+    @procurement_area_location.destroy
+
+    redirect_to procurement_area_path(procurement_area)
+  end
+
   private
 
   def procurement_area

--- a/app/models/procurement_area.rb
+++ b/app/models/procurement_area.rb
@@ -12,4 +12,12 @@ class ProcurementArea < ActiveRecord::Base
 
     save!
   end
+
+  def destroy_location!(location_uid)
+    locations.reject! do |location|
+      location["uid"] == location_uid
+    end
+
+    save!
+  end
 end

--- a/app/models/procurement_area_location.rb
+++ b/app/models/procurement_area_location.rb
@@ -26,6 +26,10 @@ class ProcurementAreaLocation
     end
   end
 
+  def destroy
+    procurement_area.destroy_location!(location_params[:uid])
+  end
+
   private
 
   attr_reader :location_params, :procurement_area, :organisations

--- a/app/views/procurement_areas/show.html.erb
+++ b/app/views/procurement_areas/show.html.erb
@@ -23,7 +23,7 @@
 
     <ul>
     <% @procurement_area.locations.each do |location| %>
-      <li><%= location.name %></li>
+      <li><%= location.name %> - <%= link_to "Delete location", procurement_area_location_path(procurement_area_id: @procurement_area.id, location_uid: location.uid), method: :delete, data: { confirm: "Are you sure?" } %></li>
     <% end %>
     </ul>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "dashboards#show"
 
   resources :procurement_areas
-  resources :procurement_area_locations, only: [:new, :create]
+  resources :procurement_area_locations, only: [:new, :create, :destroy]
   resources :procurement_area_memberships, only: [:new, :create, :destroy]
 
   get "/dashboard", to: "dashboards#show", as: :dashboard

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,5 +21,9 @@ FactoryGirl.define do
     trait :with_members do
       memberships { [] }
     end
+
+    trait :with_locations do
+      locations { [] }
+    end
   end
 end

--- a/spec/features/user_manages_procurement_areas_spec.rb
+++ b/spec/features/user_manages_procurement_areas_spec.rb
@@ -108,4 +108,27 @@ RSpec.feature "User manages procurement areas" do
 
     expect(page).to have_content "Brighton Custody Suite"
   end
+
+  scenario "removing a location from a procurement area" do
+    set_data_api_to FakeDataApis::FakeLocationsApi
+
+    location = {
+      name: "Brighton Custody Suite",
+      uid: "2345678901bcdefa"
+    }
+    admin_user = create :admin_user
+    create :procurement_area, :with_locations, name: "The Dig", locations: [
+      {
+        uid: location[:uid],
+        type: "custody_suite"
+      }
+    ]
+
+    login_with admin_user
+    click_link "Procurement areas"
+    click_link "View"
+    click_link "Delete location"
+
+    expect(page).not_to have_content "Brighton Custody Suite"
+  end
 end

--- a/spec/models/procurement_area_location_spec.rb
+++ b/spec/models/procurement_area_location_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe ProcurementAreaLocation, "#save" do
   end
 end
 
+RSpec.describe ProcurementAreaMembership, "#destroy" do
+  it "removes the provided member from the procurement area locations" do
+    procurement_area = spy(:procurement_area)
+    organisations = []
+    location_params = { uid: "bcd234" }
+
+    ProcurementAreaLocation.new(procurement_area, organisations, location_params).destroy
+
+    expect(procurement_area).to have_received(:destroy_location!).with("bcd234")
+  end
+end
+
 RSpec.describe ProcurementAreaLocation, "#eligible_organisations" do
   it "returns only organisations eligible to add as locations" do
     existing_location = { uid: "123", type: "existing example" }

--- a/spec/models/procurement_area_spec.rb
+++ b/spec/models/procurement_area_spec.rb
@@ -33,3 +33,18 @@ RSpec.describe ProcurementArea, "#destroy_membership!" do
     expect(area.memberships).to be_blank
   end
 end
+
+RSpec.describe ProcurementArea, "#destroy_location!" do
+  it "removes the location with the given location uid" do
+    area = create(:procurement_area, locations: [
+      {
+        uid: "bcd234",
+        type: "custody_suite"
+      }
+    ])
+
+    area.destroy_location!("bcd234")
+
+    expect(area.locations).to be_blank
+  end
+end


### PR DESCRIPTION
* Creates a new `ProcurementAreaLocation` object, whose `destroy` method delegates back to the `ProcurementArea` for deletion.