### PR TITLE
Introduce Shifts resource

### DIFF
--- a/app/controllers/location_shifts_controller.rb
+++ b/app/controllers/location_shifts_controller.rb
@@ -1,0 +1,79 @@
+class LocationShiftsController < ApplicationController
+  def show
+    @location = location
+    @location_shifts = Shift.for(location).map do |shift|
+      LocationShift.new(shift)
+    end
+  end
+
+  def new
+    @location_shift_form = LocationShiftForm.new(location_uid: location.uid)
+  end
+
+  def create
+    @location_shift_form = LocationShiftForm.new(
+      location_shift_params_from(params[:location_shift_form])
+    )
+
+    if @location_shift_form.submit
+      redirect_to location_shift_path(
+        @location_shift_form.location_shift,
+        location_id: @location_shift_form.location_uid
+      )
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @location_shift = location_shift
+  end
+
+  def update
+    @location_shift = location_shift
+
+    if @location_shift.update_attributes(location_shift_params_from params[:shift])
+      redirect_to location_shift_path(
+        @location_shift,
+        location_id: @location_shift.location_uid
+      )
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @location_shift = location_shift
+
+    @location_shift.destroy
+
+    redirect_to location_shift_path(location_id: @location_shift.location_uid)
+  end
+
+  private
+
+  def location
+    OrganisationFinder.new(api_client, uid: location_id).find
+  end
+
+  def location_shift
+    Shift.find(params[:id])
+  end
+
+  def api_client
+    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
+  end
+
+  def location_id
+    params[:location_id]
+  end
+
+  def location_shift_params_from(action_params)
+    {
+      name: action_params.fetch(:name),
+      location_uid: action_params.fetch(:location_uid),
+      starting_time: StartingTime.new(action_params).build,
+      ending_time: EndingTime.new(action_params).build,
+    }
+  end
+end

--- a/app/forms/location_shift_form.rb
+++ b/app/forms/location_shift_form.rb
@@ -1,0 +1,28 @@
+class LocationShiftForm
+  include ActiveModel::Model
+
+  attr_accessor :ending_time, :location_uid, :name, :starting_time, :location_shift
+
+  validates :location_uid, presence: true
+  validates :starting_time, presence: true
+
+  def submit
+    if valid?
+      self.location_shift = create_shift!
+      true
+    else
+      false
+    end
+  end
+
+  private
+
+  def create_shift!
+    Shift.create!(
+      name: name,
+      location_uid: location_uid,
+      ending_time: ending_time,
+      starting_time: starting_time
+    )
+  end
+end

--- a/app/models/ending_time.rb
+++ b/app/models/ending_time.rb
@@ -1,0 +1,21 @@
+class EndingTime
+  def initialize(params)
+    @ending_time_params = params.select { |key, _| key.include?("ending_time") }
+  end
+
+  def build
+    if ending_time.empty? || ending_time == ":"
+      nil
+    else
+      Time.parse(ending_time).to_s
+    end
+  end
+
+  private
+
+  attr_reader :ending_time_params
+
+  def ending_time
+    ending_time_params.values.last(2).join(":").to_s
+  end
+end

--- a/app/models/location_shift.rb
+++ b/app/models/location_shift.rb
@@ -1,0 +1,41 @@
+class LocationShift
+  def initialize(shift)
+    @shift = shift
+  end
+
+  def id
+    shift.id
+  end
+
+  def to_partial_path
+    "location_shifts/location_shift"
+  end
+
+  def info
+    "#{name} - #{starting_time} / #{ending_time}"
+  end
+
+  private
+
+  attr_reader :shift
+
+  def name
+    if shift.name.empty?
+      "N/A"
+    else
+      shift.name
+    end
+  end
+
+  def starting_time
+    shift.starting_time.to_formatted_s(:time)
+  end
+
+  def ending_time
+    if shift.ending_time
+      shift.ending_time.to_formatted_s(:time)
+    else
+      "until release"
+    end
+  end
+end

--- a/app/models/organisation_finder.rb
+++ b/app/models/organisation_finder.rb
@@ -8,6 +8,10 @@ class OrganisationFinder
     api_client.organisations(options)
   end
 
+  def find
+    api_client.organisation(options.fetch(:uid))
+  end
+
   private
 
   attr_reader :api_client, :options

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,0 +1,8 @@
+class Shift < ActiveRecord::Base
+  validates :location_uid, presence: true
+  validates :starting_time, presence: true
+
+  def self.for(location)
+    where(location_uid: location.uid).order(:name)
+  end
+end

--- a/app/models/starting_time.rb
+++ b/app/models/starting_time.rb
@@ -1,0 +1,21 @@
+class StartingTime
+  def initialize(params)
+    @starting_time_params = params.select { |key, _| key.include?("starting_time") }
+  end
+
+  def build
+    if starting_time.empty? || starting_time == ":"
+      ""
+    else
+      Time.parse(starting_time).to_s
+    end
+  end
+
+  private
+
+  attr_reader :starting_time_params
+
+  def starting_time
+    starting_time_params.values.last(2).join(":").to_s
+  end
+end

--- a/app/views/location_shifts/_location_shift.html.erb
+++ b/app/views/location_shifts/_location_shift.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <p><%= location_shift.info %></p>
+  <%= link_to "Edit shift", edit_location_shift_path(location_shift.id) %>
+  <%= link_to "Delete shift", location_shift_path(location_shift.id), method: :delete  %>
+</div>

--- a/app/views/location_shifts/edit.html.erb
+++ b/app/views/location_shifts/edit.html.erb
@@ -1,0 +1,14 @@
+<%= form_for @location_shift, url: location_shift_path, method: :patch do |form| %>
+  <%= form.hidden_field :location_uid, value: @location_shift.location_uid %>
+
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <%= form.label :starting_time %>
+  <%= form.time_select :starting_time, minute_step: 15 %>
+
+  <%= form.label :ending_time %>
+  <%= form.time_select :ending_time, include_blank: true, minute_step: 15 %>
+
+  <%= form.submit "Update shift" %>
+<% end %>>

--- a/app/views/location_shifts/new.html.erb
+++ b/app/views/location_shifts/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Add a new shift</h2>
+
+<%= form_for @location_shift_form, url: location_shifts_path do |form| %>
+  <%= form.hidden_field :location_uid, value: @location_shift_form.location_uid %>
+
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <%= form.label :starting_time %>
+  <%= form.time_select :starting_time, minute_step: 15 %>
+
+  <%= form.label :ending_time %>
+  <%= form.time_select :ending_time, include_blank: true, minute_step: 15 %>
+
+  <%= form.submit "Create shift" %>
+<% end %>

--- a/app/views/location_shifts/show.html.erb
+++ b/app/views/location_shifts/show.html.erb
@@ -1,0 +1,5 @@
+<h2>Manage shifts for <%= @location.name %></h2>
+
+<%= link_to "Add shift", new_location_shift_path(location_id: @location.uid) %>
+
+<%= render @location_shifts %>

--- a/app/views/procurement_areas/show.html.erb
+++ b/app/views/procurement_areas/show.html.erb
@@ -23,7 +23,11 @@
 
     <ul>
     <% @procurement_area.locations.each do |location| %>
-      <li><%= location.name %> - <%= link_to "Delete location", procurement_area_location_path(procurement_area_id: @procurement_area.id, location_uid: location.uid), method: :delete, data: { confirm: "Are you sure?" } %></li>
+      <li>
+        <%= location.name %>
+        <%= link_to "Manage shifts", location_shift_path(location_id: location.uid) %>
+        <%= link_to "Delete location", procurement_area_location_path(procurement_area_id: @procurement_area.id, location_uid: location.uid), method: :delete, data: { confirm: "Are you sure?" } %>
+      </li>
     <% end %>
     </ul>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root "dashboards#show"
 
+  resources :location_shifts
   resources :procurement_areas
   resources :procurement_area_locations, only: [:new, :create, :destroy]
   resources :procurement_area_memberships, only: [:new, :create, :destroy]

--- a/db/migrate/20150506155028_create_shifts.rb
+++ b/db/migrate/20150506155028_create_shifts.rb
@@ -1,0 +1,14 @@
+class CreateShifts < ActiveRecord::Migration
+  def change
+    create_table :shifts do |t|
+      t.string :name
+      t.string :location_uid, null: false
+      t.time :starting_time
+      t.time :ending_time
+
+      t.timestamps null: false
+    end
+
+    add_index :shifts, :location_uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505143151) do
+ActiveRecord::Schema.define(version: 20150506155028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,14 +27,15 @@ ActiveRecord::Schema.define(version: 20150505143151) do
   add_index "procurement_areas", ["locations"], name: "index_procurement_areas_on_locations", using: :gin
   add_index "procurement_areas", ["memberships"], name: "index_procurement_areas_on_memberships", using: :gin
 
-  create_table "users", force: :cascade do |t|
-    t.integer  "defence_request_uid"
-    t.integer  "defence_request_access_token"
-    t.string   "email"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "shifts", force: :cascade do |t|
+    t.string   "name"
+    t.string   "location_uid",  null: false
+    t.time     "starting_time"
+    t.time     "ending_time"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
-  add_index "users", ["defence_request_uid", "defence_request_access_token", "email"], name: "user_unique_index", unique: true, using: :btree
+  add_index "shifts", ["location_uid"], name: "index_shifts_on_location_uid", using: :btree
 
 end

--- a/spec/controllers/location_shifts_controller_spec.rb
+++ b/spec/controllers/location_shifts_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe LocationShiftsController do
+  include FakeDataApis
+
+  describe "POST create" do
+    it "renders new if the shift could not be added" do
+      set_data_api_to FakeDataApis::FakeLocationsApi
+      stub_signed_in_user
+      location_shift_params = {
+        location_shift_form: {
+          name: "",
+          location_uid: "abc"
+        }
+      }
+
+      post :create, location_shift_params
+
+      expect(response).to render_template :new
+    end
+  end
+
+  describe "PATCH update" do
+    it "renders edit if the shift could not be updated" do
+      set_data_api_to FakeDataApis::FakeLocationsApi
+      stub_signed_in_user
+      shift = create :shift
+      location_shift_params = {
+        id: shift.id,
+        shift: {
+          name: "",
+          starting_time: nil,
+          location_uid: shift.location_uid
+        }
+      }
+
+      patch :update, location_shift_params
+
+      expect(response).to render_template :edit
+    end
+  end
+
+  def stub_signed_in_user
+    allow_any_instance_of(LocationShiftsController).
+      to receive(:current_user).and_return(double(:mock_user))
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,4 +26,9 @@ FactoryGirl.define do
       locations { [] }
     end
   end
+
+  factory :shift do
+    location_uid { SecureRandom.uuid }
+    starting_time { Time.parse("09:00") }
+  end
 end

--- a/spec/features/user_manages_location_shifts_spec.rb
+++ b/spec/features/user_manages_location_shifts_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.feature "User manages location shifts" do
+  background { set_data_api_to FakeDataApis::FakeLocationsApi }
+
+  scenario "creating a shift" do
+    locations = [
+      {
+        uid: "2345678901bcdefa",
+        type: "custody_suite"
+      }
+    ]
+    procurement_area = create(
+      :procurement_area,
+      name: "Tatooine",
+      locations: locations
+    )
+    admin_user = create :admin_user
+    login_with admin_user
+
+    visit procurement_area_path procurement_area
+    click_link "Manage shifts"
+    click_link "Add shift"
+    fill_in "Name", with: "Morning shift"
+    select "08", from: "location_shift_form_starting_time_4i"
+    select "00", from: "location_shift_form_starting_time_5i"
+    select "20", from: "location_shift_form_ending_time_4i"
+    select "00", from: "location_shift_form_ending_time_5i"
+    click_button "Create shift"
+
+    expect(page).to have_content "Morning shift - 08:00 / 20:00"
+  end
+
+  scenario "editing a shift" do
+    locations = [
+      {
+        uid: "2345678901bcdefa",
+        type: "custody_suite"
+      }
+    ]
+    procurement_area = create(
+      :procurement_area,
+      name: "Tatooine",
+      locations: locations
+    )
+    create(
+      :shift,
+      name: "The Grind",
+      location_uid: locations.first[:uid],
+      starting_time: "06:00"
+    )
+    admin_user = create :admin_user
+    login_with admin_user
+
+    visit procurement_area_path procurement_area
+    click_link "Manage shifts"
+    click_link "Edit shift"
+    fill_in "Name", with: "No longer the Grind"
+    select "10", from: "shift_starting_time_4i"
+    select "00", from: "shift_starting_time_5i"
+    select "11", from: "shift_ending_time_4i"
+    select "30", from: "shift_ending_time_5i"
+    click_button "Update shift"
+
+    expect(page).to have_content "No longer the Grind - 10:00 / 11:30"
+  end
+
+  scenario "deleting a shift" do
+    locations = [
+      {
+        uid: "2345678901bcdefa",
+        type: "custody_suite"
+      }
+    ]
+    procurement_area = create(
+      :procurement_area,
+      name: "Tatooine",
+      locations: locations
+    )
+    create(
+      :shift,
+      name: "The Grind",
+      location_uid: locations.first[:uid],
+      starting_time: "06:00"
+    )
+    admin_user = create :admin_user
+    login_with admin_user
+
+    visit procurement_area_path procurement_area
+    click_link "Manage shifts"
+    click_link "Delete shift"
+
+    expect(page).not_to have_content "The Grind"
+  end
+end

--- a/spec/forms/location_shift_form_spec.rb
+++ b/spec/forms/location_shift_form_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe LocationShiftForm, "#submit" do
+  context "with valid data submission" do
+    it "creates a shift from the data submitted" do
+      data = {
+        name: "Morning Shift",
+        location_uid: SecureRandom.uuid,
+        starting_time: Time.parse("08:00"),
+        ending_time: Time.parse("10:00"),
+      }
+      form = LocationShiftForm.new(data)
+
+      form.submit
+
+      expect(form.location_shift).to be_an_instance_of(Shift)
+    end
+  end
+
+  context "with invalid data submission" do
+    it "does not create a shift" do
+      data = { location_uid: "", starting_time: "" }
+      form = LocationShiftForm.new(data)
+
+      expect(Shift).not_to receive(:create!)
+      expect(form.submit).to eq false
+      expect(form.errors.full_messages).to eq(
+        ["Location uid can't be blank", "Starting time can't be blank"]
+      )
+    end
+  end
+end

--- a/spec/models/ending_time_spec.rb
+++ b/spec/models/ending_time_spec.rb
@@ -1,0 +1,45 @@
+require_relative "../../app/models/ending_time"
+
+RSpec.describe EndingTime, "#build" do
+  context "when provided with ending time information" do
+    it "returns a parsed time string" do
+      ending_time_information = {
+        "ending_time(1i)" => "2015",
+        "ending_time(2i)" => "5",
+        "ending_time(3i)" => "11",
+        "ending_time(4i)" => "08",
+        "ending_time(5i)" => "00",
+      }
+
+      ending_time = EndingTime.new(ending_time_information).build
+
+      expect(ending_time).to eq Time.parse("08:00").to_s
+    end
+  end
+
+  context "when the ending time information is blank" do
+    it "returns nil" do
+      ending_time_information = {
+        "ending_time(1i)" => "2015",
+        "ending_time(2i)" => "5",
+        "ending_time(3i)" => "11",
+        "ending_time(4i)" => "",
+        "ending_time(5i)" => "",
+      }
+
+      ending_time = EndingTime.new(ending_time_information).build
+
+      expect(ending_time).to eq nil
+    end
+  end
+
+  context "when no ending time information is provided" do
+    it "returns nil" do
+      ending_time_information = {}
+
+      ending_time = EndingTime.new(ending_time_information).build
+
+      expect(ending_time).to eq nil
+    end
+  end
+end

--- a/spec/models/location_shift_spec.rb
+++ b/spec/models/location_shift_spec.rb
@@ -1,0 +1,49 @@
+require_relative "../../app/models/location_shift"
+require "active_support/core_ext/time/conversions"
+
+RSpec.describe LocationShift, "#info" do
+  context "for a shift with starting and ending time" do
+    it "returns a representation of the shift information" do
+      shift = double(
+        :shift,
+        name: "Example shift",
+        starting_time: Time.parse("08:00"),
+        ending_time: Time.parse("17:00")
+      )
+
+      location_shift_info = LocationShift.new(shift).info
+
+      expect(location_shift_info).to eq "Example shift - 08:00 / 17:00"
+    end
+  end
+
+  context "for a shift with only a name and starting time" do
+    it "returns a representation of the shift information" do
+      shift = double(
+        :shift,
+        name: "Example shift",
+        starting_time: Time.parse("08:00"),
+        ending_time: nil
+      )
+
+      location_shift_info = LocationShift.new(shift).info
+
+      expect(location_shift_info).to eq "Example shift - 08:00 / until release"
+    end
+  end
+
+  context "for a shift without a name" do
+    it "returns a representation of the shift information" do
+      shift = double(
+        :shift,
+        name: "",
+        starting_time: Time.parse("08:00"),
+        ending_time: Time.parse("17:00")
+      )
+
+      location_shift_info = LocationShift.new(shift).info
+
+      expect(location_shift_info).to eq "N/A - 08:00 / 17:00"
+    end
+  end
+end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Shift, "validations" do
+  it { should validate_presence_of(:location_uid) }
+  it { should validate_presence_of(:starting_time) }
+end
+
+RSpec.describe Shift, ".for" do
+  it "returns the shifts for a given location" do
+    location = double(:location, uid: "1")
+    create :shift, name: "Shift for location 1", location_uid: location.uid
+    create :shift, name: "Other shift"
+    create :shift, name: "Late Shift for location 1", location_uid: location.uid
+
+    location_shifts = Shift.for(location)
+
+    expect(location_shifts.map(&:name)).to eq(
+      ["Late Shift for location 1", "Shift for location 1"]
+    )
+  end
+end

--- a/spec/models/starting_time_spec.rb
+++ b/spec/models/starting_time_spec.rb
@@ -1,0 +1,45 @@
+require_relative "../../app/models/starting_time"
+
+RSpec.describe StartingTime, "#build" do
+  context "when provided with starting time information" do
+    it "returns a parsed time string" do
+      starting_time_information = {
+        "starting_time(1i)" => "2015",
+        "starting_time(2i)" => "5",
+        "starting_time(3i)" => "11",
+        "starting_time(4i)" => "08",
+        "starting_time(5i)" => "00",
+      }
+
+      starting_time = StartingTime.new(starting_time_information).build
+
+      expect(starting_time).to eq Time.parse("08:00").to_s
+    end
+  end
+
+  context "when the starting time information is blank" do
+    it "returns an empty string" do
+      starting_time_information = {
+        "starting_time(1i)" => "2015",
+        "starting_time(2i)" => "5",
+        "starting_time(3i)" => "11",
+        "starting_time(4i)" => "",
+        "starting_time(5i)" => "",
+      }
+
+      starting_time = StartingTime.new(starting_time_information).build
+
+      expect(starting_time).to eq ""
+    end
+  end
+
+  context "when no starting time information is provided" do
+    it "returns an empty string" do
+      starting_time_information = {}
+
+      starting_time = StartingTime.new(starting_time_information).build
+
+      expect(starting_time).to eq ""
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ unless ENV["NO_COVERAGE"]
   end
 
   SimpleCov.start "rails" do
-    add_group "Services", "app/services/auth_service"
+    add_group "Forms", "app/forms"
 
     if defined?(CodeClimate)
       formatter SimpleCov::Formatter::MultiFormatter[

--- a/spec/support/features/fake_data_api.rb
+++ b/spec/support/features/fake_data_api.rb
@@ -31,6 +31,10 @@ module FakeDataApis
       @token = token
     end
 
+    def organisation(uid)
+      organisations.detect { |org| org.uid == uid }
+    end
+
     def organisations(options = {})
       [
         OpenStruct.new(


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/93192076

Shifts belong to a location and have an name, starting time and ending time. The only required attributes so far are the location uid and starting time.

This introduces a form object as well as two models dedicated to converting start/end times into appropriate values. Since Rails `time_select` helper introduces hidden date fields, we have to handle
separating those from the actual time of arrival. Another side effect of the hidden fields is that is effectively not possible to have a "nil" end time as require in this feature. The reason for that is that the
date will be passed to ActiveRecord which will convert the empty time strings to a time of `0:00`. The solution here introduces two objects responsible for coercing the params to values that allow the feature to be implemented.