### PR TITLE
Adds law firm allocation required daily to Shifts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,5 +11,9 @@
  * file per style scope.
  *
  *= require govuk_elements_extensions
- *
+ *= require_self
  */
+
+.inline-time-selects select {
+  display: inline;
+}

--- a/app/controllers/location_shifts_controller.rb
+++ b/app/controllers/location_shifts_controller.rb
@@ -1,6 +1,7 @@
 class LocationShiftsController < ApplicationController
   def show
     @location = location
+
     @location_shifts = Shift.for(location).map do |shift|
       LocationShift.new(shift)
     end

--- a/app/controllers/shift_requirements_controller.rb
+++ b/app/controllers/shift_requirements_controller.rb
@@ -1,0 +1,23 @@
+class ShiftRequirementsController < ApplicationController
+  def edit
+    @shift = shift
+  end
+
+  def update
+    @shift = shift
+
+    @shift.update_attributes(shift_requirements_params)
+
+    redirect_to location_shift_path(@shift, location_id: @shift.location_uid)
+  end
+
+  private
+
+  def shift
+    Shift.find(params[:id])
+  end
+
+  def shift_requirements_params
+    params.require(:shift).permit(Date::DAYS_INTO_WEEK.keys)
+  end
+end

--- a/app/controllers/shift_requirements_controller.rb
+++ b/app/controllers/shift_requirements_controller.rb
@@ -6,9 +6,11 @@ class ShiftRequirementsController < ApplicationController
   def update
     @shift = shift
 
-    @shift.update_attributes(shift_requirements_params)
-
-    redirect_to location_shift_path(@shift, location_id: @shift.location_uid)
+    if @shift.update_attributes(shift_requirements_params)
+      redirect_to location_shift_path(@shift, location_id: @shift.location_uid)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/forms/location_shift_form.rb
+++ b/app/forms/location_shift_form.rb
@@ -22,7 +22,15 @@ class LocationShiftForm
       name: name,
       location_uid: location_uid,
       ending_time: ending_time,
-      starting_time: starting_time
+      starting_time: starting_time,
+      allocation_requirements_per_weekday: generate_default_requirements
     )
+  end
+
+  def generate_default_requirements
+    Date::DAYS_INTO_WEEK.keys.inject({}) do |result, key|
+      result[key] = 0
+      result
+    end
   end
 end

--- a/app/models/location_shift.rb
+++ b/app/models/location_shift.rb
@@ -1,10 +1,8 @@
 class LocationShift
+  delegate :id, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday, to: :shift
+
   def initialize(shift)
     @shift = shift
-  end
-
-  def id
-    shift.id
   end
 
   def to_partial_path

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,4 +1,6 @@
 class Shift < ActiveRecord::Base
+  store_accessor :allocation_requirements_per_weekday, Date::DAYS_INTO_WEEK.keys
+
   validates :location_uid, presence: true
   validates :starting_time, presence: true
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -4,6 +4,18 @@ class Shift < ActiveRecord::Base
   validates :location_uid, presence: true
   validates :starting_time, presence: true
 
+  validates_numericality_of(
+    :monday,
+    :tuesday,
+    :wednesday,
+    :thursday,
+    :friday,
+    :saturday,
+    :sunday,
+    only_integer: true,
+    greater_than_or_equal_to: 0
+  )
+
   def self.for(location)
     where(location_uid: location.uid).order(:name)
   end

--- a/app/views/location_shifts/_location_shift.html.erb
+++ b/app/views/location_shifts/_location_shift.html.erb
@@ -1,5 +1,35 @@
 <div>
-  <p><%= location_shift.info %></p>
+  <h2><%= location_shift.info %></h2>
+
   <%= link_to "Edit shift", edit_location_shift_path(location_shift.id) %>
   <%= link_to "Delete shift", location_shift_path(location_shift.id), method: :delete  %>
+
+  <div>
+    <h3>Number of law firms required per weekday</h3>
+
+    <div>
+      <%= link_to "Manage daily requirements for shift", edit_shift_requirement_path(location_shift.id) %>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+        <% Date::DAYNAMES.rotate.each do |weekday| %>
+          <th><%= weekday %></th>
+        <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><%= location_shift.monday %></td>
+          <td><%= location_shift.tuesday %></td>
+          <td><%= location_shift.wednesday %></td>
+          <td><%= location_shift.thursday %></td>
+          <td><%= location_shift.friday %></td>
+          <td><%= location_shift.saturday %></td>
+          <td><%= location_shift.sunday %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/location_shifts/edit.html.erb
+++ b/app/views/location_shifts/edit.html.erb
@@ -1,3 +1,5 @@
+<h2>Edit a shift</h2>
+
 <%= form_for @location_shift, url: location_shift_path, method: :patch do |form| %>
   <%= form.hidden_field :location_uid, value: @location_shift.location_uid %>
 
@@ -11,4 +13,4 @@
   <%= form.time_select :ending_time, include_blank: true, minute_step: 15 %>
 
   <%= form.submit "Update shift" %>
-<% end %>>
+<% end %>

--- a/app/views/location_shifts/edit.html.erb
+++ b/app/views/location_shifts/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit a shift</h2>
 
-<%= form_for @location_shift, url: location_shift_path, method: :patch do |form| %>
+<%= form_for @location_shift, url: location_shift_path, method: :patch, html: { class: "inline-time-selects" } do |form| %>
   <%= form.hidden_field :location_uid, value: @location_shift.location_uid %>
 
   <%= form.label :name %>
@@ -12,5 +12,7 @@
   <%= form.label :ending_time %>
   <%= form.time_select :ending_time, include_blank: true, minute_step: 15 %>
 
-  <%= form.submit "Update shift" %>
+  <div>
+    <%= form.submit "Update shift" %>
+  </div>
 <% end %>

--- a/app/views/location_shifts/new.html.erb
+++ b/app/views/location_shifts/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Add a new shift</h2>
 
-<%= form_for @location_shift_form, url: location_shifts_path do |form| %>
+<%= form_for @location_shift_form, url: location_shifts_path, html: { class: "inline-time-selects" } do |form| %>
   <%= form.hidden_field :location_uid, value: @location_shift_form.location_uid %>
 
   <%= form.label :name %>

--- a/app/views/shift_requirements/edit.html.erb
+++ b/app/views/shift_requirements/edit.html.erb
@@ -1,0 +1,29 @@
+<h3>Daily Requirements</h3>
+
+<%= form_for @shift, url: shift_requirement_path, method: :patch do |form| %>
+
+  <%= form.label :monday %>
+  <%= form.number_field :monday, step: 1, min: 0, value: @shift.monday %>
+
+  <%= form.label :tuesday %>
+  <%= form.number_field :tuesday, step: 1, min: 0, value: @shift.tuesday %>
+
+  <%= form.label :wednesday %>
+  <%= form.number_field :wednesday, step: 1, min: 0, value: @shift.wednesday %>
+
+  <%= form.label :thursday %>
+  <%= form.number_field :thursday, step: 1, min: 0, value: @shift.thursday %>
+
+  <%= form.label :friday %>
+  <%= form.number_field :friday, step: 1, min: 0, value: @shift.friday %>
+
+  <%= form.label :saturday %>
+  <%= form.number_field :saturday, step: 1, min: 0, value: @shift.saturday %>
+
+  <%= form.label :sunday %>
+  <%= form.number_field :sunday, step: 1, min: 0, value: @shift.sunday %>
+
+  <div>
+    <%= form.submit "Update requirements" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :procurement_areas
   resources :procurement_area_locations, only: [:new, :create, :destroy]
   resources :procurement_area_memberships, only: [:new, :create, :destroy]
+  resources :shift_requirements, only: [:edit, :update]
 
   get "/dashboard", to: "dashboards#show", as: :dashboard
   get "/auth/:provider/callback", to: "sessions#create"

--- a/db/migrate/20150508101320_add_day_requirements_to_shift.rb
+++ b/db/migrate/20150508101320_add_day_requirements_to_shift.rb
@@ -1,0 +1,6 @@
+class AddDayRequirementsToShift < ActiveRecord::Migration
+  def change
+    add_column :shifts, :allocation_requirements_per_weekday, :jsonb, default: "{}"
+    add_index :shifts, :allocation_requirements_per_weekday, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150506155028) do
+ActiveRecord::Schema.define(version: 20150508101320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,13 +29,15 @@ ActiveRecord::Schema.define(version: 20150506155028) do
 
   create_table "shifts", force: :cascade do |t|
     t.string   "name"
-    t.string   "location_uid",  null: false
+    t.string   "location_uid",                                     null: false
     t.time     "starting_time"
     t.time     "ending_time"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.jsonb    "allocation_requirements_per_weekday", default: {}
   end
 
+  add_index "shifts", ["allocation_requirements_per_weekday"], name: "index_shifts_on_allocation_requirements_per_weekday", using: :gin
   add_index "shifts", ["location_uid"], name: "index_shifts_on_location_uid", using: :btree
 
 end

--- a/spec/controllers/shift_requirements_controller_spec.rb
+++ b/spec/controllers/shift_requirements_controller_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe ShiftRequirementsController do
+  describe "PATCH update" do
+    it "renders edit if the shift requirements could not be updated" do
+      stub_signed_in_user
+      shift = create :shift
+      shift_params = {
+        id: shift.id,
+        shift: {
+          monday: nil,
+          tuesday: -7
+        }
+      }
+
+      patch :update, shift_params
+
+      expect(response).to render_template :edit
+    end
+  end
+
+  def stub_signed_in_user
+    allow_any_instance_of(ShiftRequirementsController).
+      to receive(:current_user).and_return(double(:mock_user))
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,5 +30,11 @@ FactoryGirl.define do
   factory :shift do
     location_uid { SecureRandom.uuid }
     starting_time { Time.parse("09:00") }
+    allocation_requirements_per_weekday {
+      Date::DAYS_INTO_WEEK.keys.inject({}) do |result, key|
+        result[key] = 0
+        result
+      end
+    }
   end
 end


### PR DESCRIPTION
Each shift now holds a `allocation_requirement_per_weekday` attribute,mapping each day of the week to the number of required firms.