### PR TITLE
Extract ApiEnabledController

### DIFF
--- a/app/controllers/api_enabled_controller.rb
+++ b/app/controllers/api_enabled_controller.rb
@@ -1,0 +1,15 @@
+class ApiEnabledController < ApplicationController
+  private
+
+  def api_client
+    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
+  end
+
+  def all_organisations_of_type(types:)
+    OrganisationFinder.new(api_client, types: types).find_all
+  end
+
+  def find_organisation_by_uid(uid:)
+    OrganisationFinder.new(api_client, uid: uid).find
+  end
+end

--- a/app/controllers/location_shifts_controller.rb
+++ b/app/controllers/location_shifts_controller.rb
@@ -1,4 +1,4 @@
-class LocationShiftsController < ApplicationController
+class LocationShiftsController < ApiEnabledController
   def show
     @location = location
 
@@ -54,27 +54,19 @@ class LocationShiftsController < ApplicationController
   private
 
   def location
-    OrganisationFinder.new(api_client, uid: location_id).find
+    find_organisation_by_uid(uid: params[:location_id])
   end
 
   def location_shift
     Shift.find(params[:id])
   end
 
-  def api_client
-    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
-  end
-
-  def location_id
-    params[:location_id]
-  end
-
-  def location_shift_params_from(action_params)
+  def location_shift_params_from(params_for_action)
     {
-      name: action_params.fetch(:name),
-      location_uid: action_params.fetch(:location_uid),
-      starting_time: StartingTime.new(action_params).build,
-      ending_time: EndingTime.new(action_params).build,
+      name: params_for_action.fetch(:name),
+      location_uid: params_for_action.fetch(:location_uid),
+      starting_time: StartingTime.new(params_for_action).build,
+      ending_time: EndingTime.new(params_for_action).build,
     }
   end
 end

--- a/app/controllers/procurement_area_locations_controller.rb
+++ b/app/controllers/procurement_area_locations_controller.rb
@@ -1,4 +1,4 @@
-class ProcurementAreaLocationsController < ApplicationController
+class ProcurementAreaLocationsController < ApiEnabledController
   def new
     @procurement_area_location = ProcurementAreaLocation.new(
       procurement_area,
@@ -34,26 +34,17 @@ class ProcurementAreaLocationsController < ApplicationController
 
   private
 
-  def procurement_area
-    ProcurementArea.find(params[:procurement_area_id])
+  def location_params
+    { uid: params.delete(:location_uid), type: params.delete(:location_type) }
   end
 
   def organisations
-    retrieve_organisations.map { |org| OrganisationPresenter.new(org) }
+    all_organisations_of_type(types: %w(court custody_suite)).map do |organisation|
+      OrganisationPresenter.new(organisation)
+    end
   end
 
-  def retrieve_organisations
-    OrganisationFinder.new(api_client, types: %w(court custody_suite)).find_all
-  end
-
-  def api_client
-    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
-  end
-
-  def location_params
-    {
-      uid: params.delete(:location_uid),
-      type: params.delete(:location_type)
-    }
+  def procurement_area
+    @_procurement_area ||= ProcurementArea.find(params[:procurement_area_id])
   end
 end

--- a/app/controllers/procurement_area_memberships_controller.rb
+++ b/app/controllers/procurement_area_memberships_controller.rb
@@ -1,4 +1,4 @@
-class ProcurementAreaMembershipsController < ApplicationController
+class ProcurementAreaMembershipsController < ApiEnabledController
   def new
     @procurement_area_membership = ProcurementAreaMembership.new(
       procurement_area,
@@ -34,26 +34,17 @@ class ProcurementAreaMembershipsController < ApplicationController
 
   private
 
-  def procurement_area
-    ProcurementArea.find(params[:procurement_area_id])
+  def membership_params
+    { uid: params.delete(:membership_uid), type: params.delete(:membership_type) }
   end
 
   def organisations
-    retrieve_organisations.map { |org| OrganisationPresenter.new(org) }
+    all_organisations_of_type(types: %w(law_firm law_office)).map do |organisation|
+      OrganisationPresenter.new(organisation)
+    end
   end
 
-  def retrieve_organisations
-    OrganisationFinder.new(api_client, types: %w(law_firm law_office)).find_all
-  end
-
-  def api_client
-    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
-  end
-
-  def membership_params
-    {
-      uid: params.delete(:membership_uid),
-      type: params.delete(:membership_type)
-    }
+  def procurement_area
+    @_procurement_area ||= ProcurementArea.find(params[:procurement_area_id])
   end
 end

--- a/app/controllers/procurement_areas_controller.rb
+++ b/app/controllers/procurement_areas_controller.rb
@@ -1,4 +1,4 @@
-class ProcurementAreasController < ApplicationController
+class ProcurementAreasController < ApiEnabledController
   def index
     @procurement_areas = ProcurementArea.ordered_by_name
   end
@@ -42,10 +42,6 @@ class ProcurementAreasController < ApplicationController
   end
 
   private
-
-  def api_client
-    DefenceRequestServiceRota.service(:auth_api).new(session[:user_token])
-  end
 
   def procurement_area_params
     params.require(:procurement_area).permit(:name)

--- a/spec/controllers/location_shifts_controller_spec.rb
+++ b/spec/controllers/location_shifts_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe LocationShiftsController do
   include FakeDataApis
 
+  it { should be_kind_of(ApiEnabledController) }
+
   describe "POST create" do
     it "renders new if the shift could not be added" do
       set_data_api_to FakeDataApis::FakeLocationsApi

--- a/spec/controllers/procurement_area_locations_controller_spec.rb
+++ b/spec/controllers/procurement_area_locations_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ProcurementAreaLocationsController do
   include FakeDataApis
 
+  it { should be_kind_of(ApiEnabledController) }
+
   describe "POST create" do
     it "adds a location to a procurement area" do
       set_data_api_to FakeDataApis::FakeLocationsApi

--- a/spec/controllers/procurement_area_memberships_controller_spec.rb
+++ b/spec/controllers/procurement_area_memberships_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ProcurementAreaMembershipsController do
   include FakeDataApis
 
+  it { should be_kind_of(ApiEnabledController) }
+
   describe "POST create" do
     it "adds a membership to a procurement area" do
       set_data_api_to FakeDataApis::FakeLawFirmsApi

--- a/spec/controllers/procurement_areas_controller_spec.rb
+++ b/spec/controllers/procurement_areas_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ProcurementAreasController do
+  it { should be_kind_of(ApiEnabledController) }
+
   describe "POST create" do
     it "saves the procurement area and redirects to index" do
       stub_signed_in_user


### PR DESCRIPTION
Controllers that required communication with the Auth API have started to accumulate some similar methods.

This moves the methods related to instantiating the AuthApi client and associated methods that make use of it to retrieve records, into a base controller.
Controllers that now require the client or any of the associated methods can be treated as extensions of ApiEnabledController.

In order to prevent regression, each of the specs for objects that extend the extracted class now include a spec to verify the extension is in place.