### PR TITLE
Ensure that RotaSlots get destroyed along with the ProcurementArea

### DIFF
--- a/app/models/procurement_area.rb
+++ b/app/models/procurement_area.rb
@@ -4,6 +4,8 @@ class ProcurementArea < ActiveRecord::Base
 
   validates :name, presence: true
 
+  has_many :rota_slots, dependent: :destroy
+
   def self.ordered_by_name
     order(name: :asc)
   end

--- a/app/models/rota_slot.rb
+++ b/app/models/rota_slot.rb
@@ -2,6 +2,7 @@ class RotaSlot < ActiveRecord::Base
   validates :date, :shift, :organisation_uid, presence: true
 
   belongs_to :shift
+  belongs_to :procurement_area
 
   scope :oldest_first, -> { order(date: :asc, shift_id: :asc) }
 end

--- a/db/migrate/20150609085241_add_foreign_key_to_rota_slots.rb
+++ b/db/migrate/20150609085241_add_foreign_key_to_rota_slots.rb
@@ -1,0 +1,11 @@
+class AddForeignKeyToRotaSlots < ActiveRecord::Migration
+  def up
+    remove_foreign_key :rota_slots, :procurement_areas
+    add_foreign_key :rota_slots, :procurement_areas, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :rota_slots, :procurement_areas
+    add_foreign_key :rota_slots, :procurement_areas
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150528120346) do
+ActiveRecord::Schema.define(version: 20150609085241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,5 +47,5 @@ ActiveRecord::Schema.define(version: 20150528120346) do
   add_index "shifts", ["allocation_requirements_per_weekday"], name: "index_shifts_on_allocation_requirements_per_weekday", using: :gin
   add_index "shifts", ["location_uid"], name: "index_shifts_on_location_uid", using: :btree
 
-  add_foreign_key "rota_slots", "procurement_areas"
+  add_foreign_key "rota_slots", "procurement_areas", on_delete: :cascade
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,6 +27,13 @@ FactoryGirl.define do
     end
   end
 
+  factory :rota_slot do
+    date { Date.today }
+    shift
+    organisation_uid { SecureRandom.uuid }
+    procurement_area
+  end
+
   factory :shift do
     location_uid { SecureRandom.uuid }
     starting_time { Time.parse("09:00") }

--- a/spec/models/procurement_area_spec.rb
+++ b/spec/models/procurement_area_spec.rb
@@ -5,7 +5,17 @@ RSpec.describe ProcurementArea, "validations" do
 end
 
 RSpec.describe ProcurementArea, "relationships" do
-  it { should have_many(:rota_slots).dependent(:destroy) }
+  it { should have_many(:rota_slots) }
+
+  it "removes any rota slots associated with it upon destroying" do
+    p = create(:procurement_area)
+
+    create_list(:rota_slot, 3, procurement_area: p)
+
+    p.destroy
+
+    expect(RotaSlot.count).to eq 0
+  end
 end
 
 RSpec.describe ProcurementArea, ".ordered_by_name" do

--- a/spec/models/procurement_area_spec.rb
+++ b/spec/models/procurement_area_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe ProcurementArea, "validations" do
   it { should validate_presence_of(:name) }
 end
 
+RSpec.describe ProcurementArea, "relationships" do
+  it { should have_many(:rota_slots).dependent(:destroy) }
+end
+
 RSpec.describe ProcurementArea, ".ordered_by_name" do
   it "returns all procurement areas ordered by name" do
     [

--- a/spec/models/rota_slot_spec.rb
+++ b/spec/models/rota_slot_spec.rb
@@ -8,4 +8,5 @@ end
 
 RSpec.describe RotaSlot, "relationships" do
   it { should belong_to(:shift) }
+  it { should belong_to(:procurement_area) }
 end


### PR DESCRIPTION
* Fixes a bug where a procurement area with active RotaSlots could not be deleted