### PR TITLE
Fix rota slot end times

### DIFF
--- a/app/models/ending_time.rb
+++ b/app/models/ending_time.rb
@@ -7,7 +7,7 @@ class EndingTime
     if ending_time.empty? || ending_time == ":"
       nil
     else
-      DateTime.parse(ending_time).to_s
+      Time.parse(ending_time).to_s
     end
   end
 

--- a/app/models/rota_slot_allocator.rb
+++ b/app/models/rota_slot_allocator.rb
@@ -31,7 +31,7 @@ class RotaSlotAllocator
     if time.nil?
       nil
     else
-      DateTime.new(date.year, date.month, date.day, time.hour, time.min, time.sec, time.zone)
+      Time.new(date.year, date.month, date.day, time.hour, time.min, time.sec)
     end
   end
 

--- a/app/models/rota_slot_allocator.rb
+++ b/app/models/rota_slot_allocator.rb
@@ -27,20 +27,35 @@ class RotaSlotAllocator
     end
   end
 
-  def compose_date_and_shift_time(date, time)
-    if time.nil?
-      nil
-    else
-      Time.new(date.year, date.month, date.day, time.hour, time.min, time.sec)
-    end
-  end
-
   def new_slot_attributes(date, shift)
     {
       shift_id: shift.id,
-      starting_time: compose_date_and_shift_time(date, shift.starting_time),
-      ending_time: compose_date_and_shift_time(date, shift.ending_time),
+      starting_time: rota_slot_start_time(date, shift),
+      ending_time: rota_slot_end_time(date, shift),
       procurement_area: procurement_area
     }
+  end
+
+  def rota_slot_start_time(date, shift)
+    shift_start_time = shift.starting_time
+
+    compose_date_and_time(date, shift_start_time)
+  end
+
+  def rota_slot_end_time(date, shift)
+    return nil if shift.ending_time.nil?
+
+    slot_end_time = compose_date_and_time(date, shift.ending_time)
+
+    shift.spans_two_days? ? slot_end_time.advance(days: 1) : slot_end_time
+  end
+
+  def compose_date_and_time(date, time)
+    Time.new(date.year,
+             date.month,
+             date.day,
+             time.hour,
+             time.min,
+             time.sec)
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -22,4 +22,9 @@ class Shift < ActiveRecord::Base
   def self.for(location_uid)
     where(location_uid: location_uid).order(:name)
   end
+
+  def spans_two_days?
+    ending_time.present? &&
+      ending_time <= starting_time
+  end
 end

--- a/app/models/starting_time.rb
+++ b/app/models/starting_time.rb
@@ -7,7 +7,7 @@ class StartingTime
     if starting_time.empty? || starting_time == ":"
       ""
     else
-      DateTime.parse(starting_time).to_s
+      Time.parse(starting_time).to_s
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
   end
 
   factory :rota_slot do
-    starting_time { DateTime.now }
+    starting_time { Time.now }
     shift
     organisation_uid { SecureRandom.uuid }
     procurement_area
@@ -36,7 +36,7 @@ FactoryGirl.define do
 
   factory :shift do
     location_uid { SecureRandom.uuid }
-    starting_time { DateTime.parse("2014-01-01 00:00") }
+    starting_time { Time.parse("2014-01-01 00:00") }
     allocation_requirements_per_weekday {
       Shift::WEEKDAYS.inject({}) do |result, key|
         result[key] = 0

--- a/spec/lib/rota_generation/allocator_spec.rb
+++ b/spec/lib/rota_generation/allocator_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe RotaGeneration::Allocator do
   describe "#mutate_slots!" do
     it "updates the slots to contain the correct organisation UIDs" do
       slots = [
-        OpenStruct.new(shift_id: 1, starting_time: DateTime.parse("01-01-2015 09:00"), organisation_uid: nil),
-        OpenStruct.new(shift_id: 2, starting_time: DateTime.parse("01-01-2015 17:00"), organisation_uid: nil),
-        OpenStruct.new(shift_id: 1, starting_time: DateTime.parse("02-01-2015 09:00"), organisation_uid: nil)
+        OpenStruct.new(shift_id: 1, starting_time: Time.parse("01-01-2015 09:00"), organisation_uid: nil),
+        OpenStruct.new(shift_id: 2, starting_time: Time.parse("01-01-2015 17:00"), organisation_uid: nil),
+        OpenStruct.new(shift_id: 1, starting_time: Time.parse("02-01-2015 09:00"), organisation_uid: nil)
       ]
 
       solution_clauses = %w{

--- a/spec/models/ending_time_spec.rb
+++ b/spec/models/ending_time_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EndingTime, "#build" do
 
       ending_time = EndingTime.new(ending_time_information).build
 
-      expect(ending_time).to eq DateTime.parse("08:00").to_s
+      expect(ending_time).to eq Time.parse("08:00").to_s
     end
   end
 

--- a/spec/models/on_duty_locator_spec.rb
+++ b/spec/models/on_duty_locator_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe OnDutyLocator, "#locate" do
   }
 
   it "returns the single uid for the organisation on duty" do
-    time = DateTime.parse("01/01/2014 20:00").iso8601
+    time = Time.parse("01/01/2014 20:00").iso8601
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("01/01/2014 12:00"),
+           starting_time: Time.parse("01/01/2014 12:00"),
            shift: first_shift)
 
     create(:rota_slot,
            organisation_uid: firm_2,
-           starting_time: DateTime.parse("01/01/2014 21:00"),
+           starting_time: Time.parse("01/01/2014 21:00"),
            shift: last_shift)
 
     on_duty_organisation_uids = OnDutyLocator.new(time, RotaSlot.order(starting_time: :desc)).locate
@@ -33,21 +33,21 @@ RSpec.describe OnDutyLocator, "#locate" do
   end
 
   it "returns multiple uids for the organisations on duty" do
-    time = DateTime.parse("01/01/2014 20:00").iso8601
+    time = Time.parse("01/01/2014 20:00").iso8601
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("01/01/2014 12:00"),
+           starting_time: Time.parse("01/01/2014 12:00"),
            shift: first_shift)
 
     create(:rota_slot,
            organisation_uid: firm_2,
-           starting_time: DateTime.parse("01/01/2014 12:00"),
+           starting_time: Time.parse("01/01/2014 12:00"),
            shift: first_shift)
 
     create(:rota_slot,
            organisation_uid: firm_3,
-           starting_time: DateTime.parse("01/01/2014 21:00"),
+           starting_time: Time.parse("01/01/2014 21:00"),
            shift: last_shift)
 
     on_duty_organisation_uids = OnDutyLocator.new(time, RotaSlot.order(starting_time: :desc)).locate
@@ -56,21 +56,21 @@ RSpec.describe OnDutyLocator, "#locate" do
   end
 
   it "returns the correct uid even if it not the first slot in time" do
-    time = DateTime.parse("01/01/2014 22:00").iso8601
+    time = Time.parse("01/01/2014 22:00").iso8601
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("01/01/2014 12:00"),
+           starting_time: Time.parse("01/01/2014 12:00"),
            shift: first_shift)
 
     create(:rota_slot,
            organisation_uid: firm_2,
-           starting_time: DateTime.parse("01/01/2014 12:00"),
+           starting_time: Time.parse("01/01/2014 12:00"),
            shift: first_shift)
 
     create(:rota_slot,
            organisation_uid: firm_3,
-           starting_time: DateTime.parse("01/01/2014 21:00"),
+           starting_time: Time.parse("01/01/2014 21:00"),
            shift: last_shift)
 
     on_duty_organisation_uids = OnDutyLocator.new(time, RotaSlot.order(starting_time: :desc)).locate
@@ -79,17 +79,17 @@ RSpec.describe OnDutyLocator, "#locate" do
   end
 
   it "returns no organisation uids if in a defined gap between shifts" do
-    time = DateTime.parse("01/01/2014 17:00")
+    time = Time.parse("01/01/2014 17:00")
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("01/01/2014 08:00"),
-           ending_time: DateTime.parse("01/01/2014 16:00"))
+           starting_time: Time.parse("01/01/2014 08:00"),
+           ending_time: Time.parse("01/01/2014 16:00"))
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("02/01/2014 08:00"),
-           ending_time: DateTime.parse("02/01/2014 16:00"))
+           starting_time: Time.parse("02/01/2014 08:00"),
+           ending_time: Time.parse("02/01/2014 16:00"))
 
     on_duty_organisation_uids = OnDutyLocator.new(time, RotaSlot.order(starting_time: :desc)).locate
 
@@ -97,12 +97,12 @@ RSpec.describe OnDutyLocator, "#locate" do
   end
 
   it "returns no organisation uids if before all slots" do
-    time = DateTime.parse("01/01/2014 06:00")
+    time = Time.parse("01/01/2014 06:00")
 
     create(:rota_slot,
            organisation_uid: firm_1,
-           starting_time: DateTime.parse("01/01/2014 08:00"),
-           ending_time: DateTime.parse("01/01/2014 16:00"))
+           starting_time: Time.parse("01/01/2014 08:00"),
+           ending_time: Time.parse("01/01/2014 16:00"))
 
     on_duty_organisation_uids = OnDutyLocator.new(time, RotaSlot.order(starting_time: :desc)).locate
 

--- a/spec/models/rota_slot_allocator_spec.rb
+++ b/spec/models/rota_slot_allocator_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.describe RotaSlotAllocator, "#allocate" do
   it "instantiates the necessary number of rota slots per shift weekday requirement" do
-    date_range = Range.new(Date.parse("1/1/2015"), Date.parse("2/1/2015"))
+    date_range = Range.new(Date.parse("1/1/2015"), Date.parse("3/1/2015"))
     shifts = [
-      build_stubbed(:shift, thursday: 1),
-      build_stubbed(:shift, friday: 1)
+      build_stubbed(:shift, thursday: 1, starting_time: "09:00"),
+      build_stubbed(:shift, friday: 1, starting_time: "11:00", ending_time: "19:00"),
+      build_stubbed(:shift, saturday: 1, starting_time: "15:00", ending_time: "15:00")
     ]
     procurement_area = build_stubbed :procurement_area
 
@@ -16,6 +17,15 @@ RSpec.describe RotaSlotAllocator, "#allocate" do
     ).allocate
 
     expect(allocation.map(&:class).uniq).to eq [RotaSlot]
-    expect(allocation.length).to eq 2
+    expect(allocation.length).to eq 3
+
+    expect(allocation[0].starting_time).to eq Time.parse("1/1/2015 09:00")
+    expect(allocation[0].ending_time).to   eq nil
+
+    expect(allocation[1].starting_time).to eq Time.parse("2/1/2015 11:00")
+    expect(allocation[1].ending_time).to   eq Time.parse("2/1/2015 19:00")
+
+    expect(allocation[2].starting_time).to eq Time.parse("3/1/2015 15:00")
+    expect(allocation[2].ending_time).to   eq Time.parse("4/1/2015 15:00")
   end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -19,3 +19,23 @@ RSpec.describe Shift, ".for" do
     )
   end
 end
+
+RSpec.describe Shift, "#spans_two_days?" do
+  it "returns false if there is no ending time" do
+    shift = build :shift, starting_time: "09:00"
+
+    expect(shift.spans_two_days?).to be_falsey
+  end
+
+  it "returns false if the ending time falls later in the same day as the start time" do
+    shift = build :shift, starting_time: "09:00", ending_time: "17:00"
+
+    expect(shift.spans_two_days?).to be_falsey
+  end
+
+  it "returns true if the ending time falls earlier (and therefore the next day)" do
+    shift = build :shift, starting_time: "17:00", ending_time: "09:00"
+
+    expect(shift.spans_two_days?).to be_truthy
+  end
+end

--- a/spec/models/starting_time_spec.rb
+++ b/spec/models/starting_time_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StartingTime, "#build" do
 
       starting_time = StartingTime.new(starting_time_information).build
 
-      expect(starting_time).to eq DateTime.parse("08:00").to_s
+      expect(starting_time).to eq Time.parse("08:00").to_s
     end
   end
 

--- a/spec/requests/api/v1/on_duty_request_spec.rb
+++ b/spec/requests/api/v1/on_duty_request_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "GET /v1/on_duty_firm/:location_uid/:time" do
     )
     create(
       :rota_slot,
-      starting_time: DateTime.parse("01/01/2014 09:00"),
-      ending_time: DateTime.parse("01/01/2014 21:00"),
+      starting_time: Time.parse("01/01/2014 09:00"),
+      ending_time: Time.parse("01/01/2014 21:00"),
       shift: create(:shift, location_uid: "93b8ef50-fe12-4d80-9e7e-05e98232ec13"),
       organisation_uid: "32252f6a-a6a5-4f52-8ede-58d6127ba231",
       procurement_area_id: procurement_area.id
@@ -22,7 +22,7 @@ RSpec.describe "GET /v1/on_duty_firm/:location_uid/:time" do
 
     get "/v1/on_duty_firm/", {
       location_uid: "93b8ef50-fe12-4d80-9e7e-05e98232ec13",
-      time: DateTime.parse("01/01/2014 20:00").iso8601,
+      time: Time.parse("01/01/2014 20:00").iso8601,
       token: "611151277c992292868f772d573da4eea4ade37e303582b328c674e8ce69b512",
     }
 


### PR DESCRIPTION
Do not merge before merging #73.

* Fixes the bug in which start and end times on RotaSlots would always be on the same day (and thus 24hr shifts would have 0 length)
* Ensures that if a shift spans over midnight, the ending time for the slot is on the following day