### PR TITLE
Rota Filter Defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem "poltergeist"
   gem "shoulda-matchers", require: false
   gem "simplecov", require: false
+  gem "timecop", require: false
   gem "webmock", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.7.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -434,6 +435,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-matchers
   simplecov
+  timecop
   uglifier (>= 1.3.0)
   unicorn (~> 4.8.3)
   web-console (~> 2.0)

--- a/app/controllers/rotas_controller.rb
+++ b/app/controllers/rotas_controller.rb
@@ -40,7 +40,11 @@ class RotasController < ApiEnabledController
   end
 
   def filter_date_range
-    FilterRange.new(params[:rota_filter]).build
+    if params[:rota_filter].present?
+      FilterRange.new(params[:rota_filter]).build
+    else
+      Range.new Time.now.beginning_of_month, Time.now.end_of_month
+    end
   end
 
   def shifts_for_location
@@ -60,7 +64,6 @@ class RotasController < ApiEnabledController
   end
 
   def rota_slots
-    slots = RotaSlot.for(procurement_area)
-    params[:rota_filter].present? ? slots.where(starting_time: filter_date_range) : slots
+    RotaSlot.for(procurement_area).where(starting_time: filter_date_range)
   end
 end

--- a/app/models/filter_range.rb
+++ b/app/models/filter_range.rb
@@ -4,18 +4,18 @@ class FilterRange
   end
 
   def build
-    Range.new starting_date, ending_date
+    Range.new starting_time, ending_time
   end
 
   private
 
   attr_reader :params
 
-  def starting_date
+  def starting_time
     Time.parse(params.select { |key, _| key.include?("starting_date") }.values.join("/")).beginning_of_day
   end
 
-  def ending_date
+  def ending_time
     Time.parse(params.select { |key, _| key.include?("ending_date") }.values.join("/")).end_of_day
   end
 end

--- a/app/views/rotas/_rota.html.erb
+++ b/app/views/rotas/_rota.html.erb
@@ -2,9 +2,9 @@
 
 <%= form_tag(procurement_area_rotas_path(@procurement_area), method: :get) do %>
   <h3>Filter</h3>
-  <%= date_select("rota_filter", "starting_date", { default: @rota.date_range.first, start_year: 2014, end_year: Date.today.year + 3, order: [:day, :month, :year] }, { class: "date-picker" }) %>
+  <%= date_select("rota_filter", "starting_date", { default: Date.today.beginning_of_month, start_year: 2014, end_year: Date.today.year + 3, order: [:day, :month, :year] }, { class: "date-picker" }) %>
   to
-  <%= date_select("rota_filter", "ending_date", { default: @rota.date_range.last, start_year: 2014, end_year: Date.today.year + 3, order: [:day, :month, :year] }, { class: "date-picker" }) %>
+  <%= date_select("rota_filter", "ending_date", { default: Date.today.end_of_month, start_year: 2014, end_year: Date.today.year + 3, order: [:day, :month, :year] }, { class: "date-picker" }) %>
   <%= submit_tag "Filter" %>
 <% end %>
 

--- a/spec/features/user_manages_rotas_spec.rb
+++ b/spec/features/user_manages_rotas_spec.rb
@@ -43,6 +43,6 @@ RSpec.feature "User manages rota" do
     select_date Date.parse("20/01/2015"), from: "rota_generation_form_ending_date"
     click_button "Generate rota"
 
-    expect(page).to have_text "Rota for Gotham"
+    expect(page).to have_text "Rotas for Gotham"
   end
 end

--- a/spec/features/user_views_rotas_spec.rb
+++ b/spec/features/user_views_rotas_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
+require "timecop"
 
 RSpec.feature "User views rota" do
   background { set_data_api_to FakeDataApis::FullDataStore }
 
-  scenario "filtering the rota by date" do
+  scenario "filtering the rota by date, with the current month as a default" do
     procurement_area = create(
       :procurement_area,
       name: "Gotham",
@@ -48,36 +49,31 @@ RSpec.feature "User views rota" do
 
     admin_user = create :admin_user
 
-    login_with admin_user
-    visit procurement_area_path procurement_area
-    click_link "Manage rotas"
+    Timecop.freeze(2015, 1, 1) do
+      login_with admin_user
+      visit procurement_area_path procurement_area
+      click_link "Manage rotas"
 
-    expect(page).to have_content("Rotas for Gotham")
+      expect(page).to have_content("Rotas for Gotham")
 
-    expect(page).to have_content("Monday, 1 Dec 2014")
-    expect(page).to have_content("Thursday, 1 Jan 2015")
-    expect(page).to have_content("Sunday, 1 Feb 2015")
+      expect(page).not_to have_content("Monday, 1 Dec 2014")
+      expect(page).to     have_content("Thursday, 1 Jan 2015")
+      expect(page).not_to have_content("Sunday, 1 Feb 2015")
 
-    select_date Date.parse("01/01/2015"), from: "rota_filter_starting_date"
-    select_date Date.parse("31/01/2015"), from: "rota_filter_ending_date"
-    click_button "Filter"
+      select_date Date.parse("01/02/2015"), from: "rota_filter_ending_date"
+      click_button "Filter"
 
-    expect(page).not_to have_content("Monday, 1 Dec 2014")
-    expect(page).to     have_content("Thursday, 1 Jan 2015")
-    expect(page).not_to have_content("Sunday, 1 Feb 2015")
+      expect(page).not_to have_content("Monday, 1 Dec 2014")
+      expect(page).to     have_content("Thursday, 1 Jan 2015")
+      expect(page).to     have_content("Sunday, 1 Feb 2015")
 
-    select_date Date.parse("01/02/2015"), from: "rota_filter_ending_date"
-    click_button "Filter"
+      select_date Date.parse("01/12/2014"), from: "rota_filter_starting_date"
+      select_date Date.parse("01/02/2015"), from: "rota_filter_ending_date"
+      click_button "Filter"
 
-    expect(page).not_to have_content("Monday, 1 Dec 2014")
-    expect(page).to     have_content("Thursday, 1 Jan 2015")
-    expect(page).to     have_content("Sunday, 1 Feb 2015")
-
-    select_date Date.parse("01/12/2014"), from: "rota_filter_starting_date"
-    click_button "Filter"
-
-    expect(page).to have_content("Monday, 1 Dec 2014")
-    expect(page).to have_content("Thursday, 1 Jan 2015")
-    expect(page).to have_content("Sunday, 1 Feb 2015")
+      expect(page).to have_content("Monday, 1 Dec 2014")
+      expect(page).to have_content("Thursday, 1 Jan 2015")
+      expect(page).to have_content("Sunday, 1 Feb 2015")
+    end
   end
 end


### PR DESCRIPTION
This was forgotten as part of PR #77.

* Ensures that the filters are set to the current month by default.