### PR TITLE
[asset_content_encoding] Revert to known-good fog-aws version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "2.2.2"
 gem "dotenv-rails", "~> 2.0.0", require: "dotenv/rails-now"
 
 gem "coffee-rails", "~> 4.1.0"
+gem "fog-aws", "= 0.1.2"          # See https://github.com/fog/fog-aws/issues/130
 gem "httparty"
 gem "icalendar"
 gem "jbuilder", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.5.0)
+    fog-aws (0.1.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -414,6 +414,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.0.0)
   drs-auth_client!
   factory_girl_rails
+  fog-aws (= 0.1.2)
   govuk_elements_rails (~> 0.1.1)
   govuk_frontend_toolkit (~> 2.0.1)
   httparty


### PR DESCRIPTION
The asset_sync gem uses fog-aws to upload assets to S3. However fog-aws > 0.1.2 sets the Content-Encoding to null value.

This gem can be removed once https://github.com/fog/fog-aws/issues/130 is correctly resolved