### PR TITLE
[add_aws_region_env_var] Add AWS_REGION env variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,3 +17,5 @@ AUTHENTICATION_APPLICATION_SECRET=FA11FA11FA11FA11FA13
 # AWS and S3 settings
 # You can only push to AWS buckets from EC2 instances in the correct IAM role:
 AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+# Shoryuken requires this ENV variable to be called AWS_REGION
+AWS_REGION=eu-west-1

--- a/.env.test
+++ b/.env.test
@@ -14,3 +14,5 @@ AUTHENTICATION_APPLICATION_SECRET='xxx'
 # AWS and S3 settings
 # You can only push to AWS buckets from EC2 instances in the correct IAM role:
 AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+# Shoryuken requires this ENV variable to be called AWS_REGION
+AWS_REGION=eu-west-1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ bank_holidays:
   file_location: <%= ENV.fetch('BANK_HOLIDAYS_FILE', Rails.root.join("data", "bank_holidays.ics")) %>
 
 aws:
-  region: eu-west-1
+  region: <%= ENV.fetch("AWS_REGION") %>
   s3_asset_bucket_name: <%= ENV.fetch("AWS_S3_ASSET_BUCKET_NAME") %>
 
 sentry:


### PR DESCRIPTION
Make projects consistent - AWS_REGION env var so that it can be used by Shoryuken and S3 asset_sync