### PR TITLE
Re-organise rota slot model

### DIFF
--- a/app/helpers/rota_helper.rb
+++ b/app/helpers/rota_helper.rb
@@ -1,22 +1,14 @@
 module RotaHelper
   def present_organisations(organisations_with_solicitors)
-    tags = organisations_with_solicitors.map do |org_hsh|
+    tags = organisations_with_solicitors.flatten.map do |org_hsh|
       org_colour = organisation_colour(org_hsh[:organisation_id])
 
-      content_tag(:span, org_and_solicitor(org_hsh),
+      content_tag(:span, org_hsh[:organisation_name],
                   class: "rota-slot-organisation #{organisation_text_class(org_colour)}",
                   style: "background-color: ##{org_colour};")
     end
 
     tags.join("</br>").html_safe
-  end
-
-  def org_and_solicitor(org_hsh)
-    str = org_hsh[:organisation_name].dup
-
-    str << " - #{org_hsh[:solicitor_name]}" if org_hsh[:solicitor_name].present?
-
-    str
   end
 
   def organisation_colour(org_uid)

--- a/app/models/rota.rb
+++ b/app/models/rota.rb
@@ -20,7 +20,7 @@ class Rota
   end
 
   def on_duty(date, shift)
-    organisations_and_solicitor_names(slots_on_duty(date, shift))
+    organisations_and_solicitor_names(slot_on_duty(date, shift))
   end
 
   def procurement_area_name
@@ -45,18 +45,18 @@ class Rota
 
   private
 
-  def slots_on_duty(date, shift)
+  def slot_on_duty(date, shift)
     rota_slots.select { |s| s.starting_time.to_date == date && s.shift_id == shift.id }
   end
 
   def organisations_and_solicitor_names(slots)
-    slots.map do |s|
-      organisation = s.organisation
-      {
-        organisation_name: organisation.name,
-        organisation_id: organisation.id,
-        solicitor_name: s.solicitor_name
-      }
+    slots.map do |slot|
+      slot.organisation_ids.map do |org_id|
+        {
+          organisation_name: Organisation.find(org_id).name,
+          organisation_id: org_id
+        }
+      end
     end
   end
 

--- a/app/models/rota_slot.rb
+++ b/app/models/rota_slot.rb
@@ -1,17 +1,14 @@
 class RotaSlot < ActiveRecord::Base
-  validates :starting_time, :shift, :organisation, presence: true
+  attr_accessor :number_of_firms_required
+
+  validates :starting_time, :shift, presence: true
 
   belongs_to :shift
   belongs_to :procurement_area
-  belongs_to :organisation
 
   scope :oldest_first, -> { order(starting_time: :asc, shift_id: :asc) }
 
   def self.for(procurement_area)
     where(procurement_area: procurement_area)
-  end
-
-  def update_request_count!
-    increment!(:request_count)
   end
 end

--- a/app/models/rota_slot.rb
+++ b/app/models/rota_slot.rb
@@ -2,6 +2,7 @@ class RotaSlot < ActiveRecord::Base
   attr_accessor :number_of_firms_required
 
   validates :starting_time, :shift, presence: true
+  validates :starting_time, uniqueness: { scope: :shift, message: "must be unique within a shift" }
 
   belongs_to :shift
   belongs_to :procurement_area

--- a/db/migrate/20150708093429_change_organisation_id_to_array_type_on_rota_slot.rb
+++ b/db/migrate/20150708093429_change_organisation_id_to_array_type_on_rota_slot.rb
@@ -1,0 +1,6 @@
+class ChangeOrganisationIdToArrayTypeOnRotaSlot < ActiveRecord::Migration
+  def change
+    add_column :rota_slots, :organisation_ids, :integer, array: true, null: false, default: []
+    remove_column :rota_slots, :organisation_id, :integer
+  end
+end

--- a/db/migrate/20150708101544_remove_solicitor_name_and_request_count_columns_from_rota_slot.rb
+++ b/db/migrate/20150708101544_remove_solicitor_name_and_request_count_columns_from_rota_slot.rb
@@ -1,0 +1,6 @@
+class RemoveSolicitorNameAndRequestCountColumnsFromRotaSlot < ActiveRecord::Migration
+  def change
+    remove_column :rota_slots, :request_count, :integer, null: false, default: 0
+    remove_column :rota_slots, :solicitor_name, :string
+  end
+end

--- a/db/migrate/20150708150342_add_unique_index_on_rota_slot.rb
+++ b/db/migrate/20150708150342_add_unique_index_on_rota_slot.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnRotaSlot < ActiveRecord::Migration
+  def change
+    add_index :rota_slots, [:shift_id, :starting_time], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -403,6 +403,13 @@ CREATE INDEX index_rota_slots_on_procurement_area_id ON rota_slots USING btree (
 
 
 --
+-- Name: index_rota_slots_on_shift_id_and_starting_time; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_rota_slots_on_shift_id_and_starting_time ON rota_slots USING btree (shift_id, starting_time);
+
+
+--
 -- Name: index_shifts_on_allocation_requirements_per_weekday; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -489,4 +496,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150706193359');
 INSERT INTO schema_migrations (version) VALUES ('20150708093429');
 
 INSERT INTO schema_migrations (version) VALUES ('20150708101544');
+
+INSERT INTO schema_migrations (version) VALUES ('20150708150342');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -182,9 +182,7 @@ CREATE TABLE rota_slots (
     procurement_area_id integer,
     starting_time timestamp without time zone,
     ending_time timestamp without time zone,
-    request_count integer DEFAULT 0 NOT NULL,
-    solicitor_name character varying,
-    organisation_id integer
+    organisation_ids integer[] DEFAULT '{}'::integer[] NOT NULL
 );
 
 
@@ -487,4 +485,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150706141631');
 INSERT INTO schema_migrations (version) VALUES ('20150706154427');
 
 INSERT INTO schema_migrations (version) VALUES ('20150706193359');
+
+INSERT INTO schema_migrations (version) VALUES ('20150708093429');
+
+INSERT INTO schema_migrations (version) VALUES ('20150708101544');
 

--- a/lib/rota_generation/allocator.rb
+++ b/lib/rota_generation/allocator.rb
@@ -8,7 +8,7 @@ module RotaGeneration
     def mutate_slots!
       split_clauses.each do |shift_id, date_of_month, month, year, firm_id|
         matching_slot = detect_matching_slot(build_date(year, month, date_of_month), shift_id)
-        matching_slot.organisation_id = firm_id.to_i if matching_slot
+        matching_slot.organisation_ids << firm_id.to_i if matching_slot
       end
       slots
     end
@@ -32,8 +32,7 @@ module RotaGeneration
     def detect_matching_slot(date, shift_id)
       slots.detect do |slot|
         slot.starting_time.to_date == date &&
-          slot.shift_id == shift_id.to_i &&
-          slot.organisation_id == nil
+          slot.shift_id == shift_id.to_i
       end
     end
   end

--- a/lib/rota_generation/fact_file_writer.rb
+++ b/lib/rota_generation/fact_file_writer.rb
@@ -81,7 +81,7 @@ module RotaGeneration
     def firm_count(shift_id, date)
       slots.detect { |slot|
         slot.shift_id == shift_id && slot.starting_time.to_date == date
-      }.number_of_firms_required
+      }.try(:number_of_firms_required) || 0
     end
 
     def number_of_firms

--- a/lib/rota_generation/fact_file_writer.rb
+++ b/lib/rota_generation/fact_file_writer.rb
@@ -79,7 +79,9 @@ module RotaGeneration
     end
 
     def firm_count(shift_id, date)
-      slots.detect { |slot| slot.shift_id == shift_id && slot.starting_time.to_date == date }.number_of_firms_required
+      slots.detect { |slot|
+        slot.shift_id == shift_id && slot.starting_time.to_date == date
+      }.number_of_firms_required
     end
 
     def number_of_firms

--- a/lib/rota_generation/fact_file_writer.rb
+++ b/lib/rota_generation/fact_file_writer.rb
@@ -79,7 +79,7 @@ module RotaGeneration
     end
 
     def firm_count(shift_id, date)
-      slots.select { |slot| slot.shift_id == shift_id && slot.starting_time.to_date == date }.count
+      slots.detect { |slot| slot.shift_id == shift_id && slot.starting_time.to_date == date }.number_of_firms_required
     end
 
     def number_of_firms

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,8 +34,8 @@ FactoryGirl.define do
   factory :rota_slot do
     starting_time { Time.now }
     shift
-    organisation
     procurement_area
+    organisation_ids { [] }
   end
 
   factory :shift do

--- a/spec/features/user_views_rotas_spec.rb
+++ b/spec/features/user_views_rotas_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "User views rota" do
                            organisation_type: "custody_suite",
                            procurement_area: procurement_area)
     law_firm = create(:organisation,
+                      name: "Best Law Firm",
                       organisation_type: "law_firm",
                       procurement_area: procurement_area)
 
@@ -23,22 +24,21 @@ RSpec.feature "User views rota" do
            procurement_area: procurement_area,
            starting_time: Time.parse("01/01/2015 09:00"),
            shift: shift,
-           organisation: law_firm
+           organisation_ids: [law_firm.id]
           )
 
     create(:rota_slot,
            procurement_area: procurement_area,
            starting_time: Time.parse("01/02/2015 09:00"),
            shift: shift,
-           organisation: law_firm,
-           solicitor_name: "Mr A Lawyer"
+           organisation_ids: [law_firm.id]
           )
 
     create(:rota_slot,
            procurement_area: procurement_area,
            starting_time: Time.parse("01/12/2014 09:00"),
            shift: shift,
-           organisation: law_firm
+           organisation_ids: [law_firm.id]
           )
 
     admin_user = create :admin_user
@@ -53,7 +53,7 @@ RSpec.feature "User views rota" do
       expect(page).not_to have_content("Monday, 1 Dec 2014")
       expect(page).to     have_content("Thursday, 1 Jan 2015")
       expect(page).not_to have_content("Sunday, 1 Feb 2015")
-      expect(page).not_to have_content("Mr A Lawyer")
+      expect(page).to     have_content("Best Law Firm", count: 1)
 
       select_date Date.parse("01/02/2015"), from: "rota_filter_ending_date"
       click_button "Filter"
@@ -61,7 +61,7 @@ RSpec.feature "User views rota" do
       expect(page).not_to have_content("Monday, 1 Dec 2014")
       expect(page).to     have_content("Thursday, 1 Jan 2015")
       expect(page).to     have_content("Sunday, 1 Feb 2015")
-      expect(page).to     have_content("Mr A Lawyer")
+      expect(page).to     have_content("Best Law Firm", count: 2)
 
       select_date Date.parse("01/12/2014"), from: "rota_filter_starting_date"
       select_date Date.parse("01/02/2015"), from: "rota_filter_ending_date"
@@ -70,7 +70,7 @@ RSpec.feature "User views rota" do
       expect(page).to have_content("Monday, 1 Dec 2014")
       expect(page).to have_content("Thursday, 1 Jan 2015")
       expect(page).to have_content("Sunday, 1 Feb 2015")
-      expect(page).to have_content("Mr A Lawyer")
+      expect(page).to have_content("Best Law Firm", count: 3)
     end
   end
 end

--- a/spec/lib/rota_generation/allocator_spec.rb
+++ b/spec/lib/rota_generation/allocator_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe RotaGeneration::Allocator do
   describe "#mutate_slots!" do
     it "updates the slots to contain the correct organisation UIDs" do
       slots = [
-        OpenStruct.new(shift_id: 1, starting_time: Time.parse("01-01-2015 09:00"), organisation_id: nil),
-        OpenStruct.new(shift_id: 2, starting_time: Time.parse("01-01-2015 17:00"), organisation_id: nil),
-        OpenStruct.new(shift_id: 1, starting_time: Time.parse("02-01-2015 09:00"), organisation_id: nil)
+        OpenStruct.new(shift_id: 1, starting_time: Time.parse("01-01-2015 09:00"), organisation_ids: []),
+        OpenStruct.new(shift_id: 2, starting_time: Time.parse("01-01-2015 17:00"), organisation_ids: []),
+        OpenStruct.new(shift_id: 1, starting_time: Time.parse("02-01-2015 09:00"), organisation_ids: [])
       ]
 
       solution_clauses = %w{
@@ -20,7 +20,7 @@ RSpec.describe RotaGeneration::Allocator do
 
       mutated_slots = RotaGeneration::Allocator.new(slots, solution_clauses).mutate_slots!
 
-      expect(mutated_slots.map(&:organisation_id)).to eq [76, 85, 45]
+      expect(mutated_slots.map(&:organisation_ids)).to eq [[76], [85], [45]]
     end
   end
 end

--- a/spec/lib/rota_generation/allocator_spec.rb
+++ b/spec/lib/rota_generation/allocator_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe RotaGeneration::Allocator do
       solution_clauses = %w{
         allocated(1,thu,1,1,2015,76).
         allocated(2,thu,1,1,2015,85).
+        allocated(2,thu,1,1,2015,96).
         allocated(1,fri,2,1,2015,45).
         allocated(3,mon,5,1,2015,76).
       }
 
       mutated_slots = RotaGeneration::Allocator.new(slots, solution_clauses).mutate_slots!
 
-      expect(mutated_slots.map(&:organisation_ids)).to eq [[76], [85], [45]]
+      expect(mutated_slots.map(&:organisation_ids)).to eq [[76], [85, 96], [45]]
     end
   end
 end

--- a/spec/models/rota_slot_allocator_spec.rb
+++ b/spec/models/rota_slot_allocator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RotaSlotAllocator, "#allocate", type: :bank_holidays do
     date_range = Range.new(Date.parse("1/1/2015"), Date.parse("3/1/2015"))
     shifts = [
       build_stubbed(:shift, thursday: 1, starting_time: "09:00"),
-      build_stubbed(:shift, friday: 1, starting_time: "11:00", ending_time: "19:00"),
+      build_stubbed(:shift, friday: 2, starting_time: "11:00", ending_time: "19:00"),
       build_stubbed(:shift, saturday: 1, starting_time: "15:00", ending_time: "15:00")
     ]
     procurement_area = build_stubbed :procurement_area
@@ -23,14 +23,17 @@ RSpec.describe RotaSlotAllocator, "#allocate", type: :bank_holidays do
     expect(allocation.map(&:class).uniq).to eq [RotaSlot]
     expect(allocation.length).to eq 3
 
-    expect(allocation[0].starting_time).to eq Time.parse("1/1/2015 09:00")
-    expect(allocation[0].ending_time).to   eq nil
+    expect(allocation[0].starting_time).to            eq Time.parse("1/1/2015 09:00")
+    expect(allocation[0].ending_time).to              eq nil
+    expect(allocation[0].number_of_firms_required).to eq 1
 
-    expect(allocation[1].starting_time).to eq Time.parse("2/1/2015 11:00")
-    expect(allocation[1].ending_time).to   eq Time.parse("2/1/2015 19:00")
+    expect(allocation[1].starting_time).to            eq Time.parse("2/1/2015 11:00")
+    expect(allocation[1].ending_time).to              eq Time.parse("2/1/2015 19:00")
+    expect(allocation[1].number_of_firms_required).to eq 2
 
-    expect(allocation[2].starting_time).to eq Time.parse("3/1/2015 15:00")
-    expect(allocation[2].ending_time).to   eq Time.parse("4/1/2015 15:00")
+    expect(allocation[2].starting_time).to            eq Time.parse("3/1/2015 15:00")
+    expect(allocation[2].ending_time).to              eq Time.parse("4/1/2015 15:00")
+    expect(allocation[2].number_of_firms_required).to eq 1
   end
 
   it "overrides the allocation for bank holidays on the correct dates " do
@@ -47,19 +50,19 @@ RSpec.describe RotaSlotAllocator, "#allocate", type: :bank_holidays do
     ).allocate
 
     expect(allocation.map(&:class).uniq).to eq [RotaSlot]
-    expect(allocation.length).to eq 4
+    expect(allocation.length).to eq 3
 
-    expect(allocation[0].starting_time).to eq Time.parse("3/1/2015 09:00")
-    expect(allocation[0].ending_time).to   eq nil
+    expect(allocation[0].starting_time).to            eq Time.parse("3/1/2015 09:00")
+    expect(allocation[0].ending_time).to              eq nil
+    expect(allocation[0].number_of_firms_required).to eq 1
 
-    expect(allocation[1].starting_time).to eq Time.parse("4/1/2015 09:00")
-    expect(allocation[1].ending_time).to   eq nil
+    expect(allocation[1].starting_time).to            eq Time.parse("4/1/2015 09:00")
+    expect(allocation[1].ending_time).to              eq nil
+    expect(allocation[1].number_of_firms_required).to eq 1
 
-    expect(allocation[2].starting_time).to eq Time.parse("5/1/2015 09:00")
-    expect(allocation[2].ending_time).to   eq nil
-
-    expect(allocation[3].starting_time).to eq Time.parse("5/1/2015 09:00")
-    expect(allocation[3].ending_time).to   eq nil
+    expect(allocation[2].starting_time).to            eq Time.parse("5/1/2015 09:00")
+    expect(allocation[2].ending_time).to              eq nil
+    expect(allocation[2].number_of_firms_required).to eq 2
   end
 
   def bank_holidays_file

--- a/spec/models/rota_slot_spec.rb
+++ b/spec/models/rota_slot_spec.rb
@@ -3,6 +3,20 @@ require "rails_helper"
 RSpec.describe RotaSlot, "validations" do
   it { should validate_presence_of(:starting_time) }
   it { should validate_presence_of(:shift) }
+
+  it "does not violate the uniquness between shift and start time" do
+    shift = create(:shift)
+
+    create(:rota_slot, shift: shift, starting_time: Time.parse("01/01/2015 09:00"))
+
+    expect(
+      build(
+        :rota_slot,
+        shift: shift,
+        starting_time: Time.parse("01/01/2015 09:00")
+      )
+    ).not_to be_valid
+  end
 end
 
 RSpec.describe RotaSlot, "relationships" do

--- a/spec/models/rota_slot_spec.rb
+++ b/spec/models/rota_slot_spec.rb
@@ -3,23 +3,9 @@ require "rails_helper"
 RSpec.describe RotaSlot, "validations" do
   it { should validate_presence_of(:starting_time) }
   it { should validate_presence_of(:shift) }
-  it { should validate_presence_of(:organisation) }
 end
 
 RSpec.describe RotaSlot, "relationships" do
   it { should belong_to(:shift) }
-  it { should belong_to(:organisation) }
   it { should belong_to(:procurement_area) }
-end
-
-RSpec.describe "#update_request_count!" do
-  it "should increment the request count" do
-    rota_slot = create(:rota_slot)
-
-    expect {
-      rota_slot.update_request_count!
-    }.to change {
-      rota_slot.request_count
-    }.by(1)
-  end
 end


### PR DESCRIPTION
* `RotaSlot`s now have an `organisation_ids` field of array type
* The model has a uniquess constraint on `[:shift, :starting_time]`
* If a rota is generated and any part of it overlaps what's already been generated, the job fails, as per this example:
![screen shot 2015-07-08 at 16 32 34](https://cloud.githubusercontent.com/assets/1398210/8574513/ef7bcd4a-258e-11e5-9f1d-6611d9a41f16.png)
