### PR TITLE
Queue all jobs into the 'default' queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "govuk_elements_rails", "~> 0.1.1"
 gem "devise"
 gem "devise-async"
 gem "drs-auth_client", github: "ministryofjustice/defence-request-service-auth", tag: "v0.2.2"
-gem "que"
+gem "que", github: "chanks/que", ref: "4e83b0"
 gem "que-web"
 
 # Asset sync - for uploading assets to S3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/chanks/que.git
+  revision: 4e83b02c8f6bb553dfe97bd3f2771f78f8d77433
+  ref: 4e83b0
+  specs:
+    que (0.10.0)
+
+GIT
   remote: git://github.com/ministryofjustice/defence-request-service-auth.git
   revision: 87e835adb75522c3cf2115ffc860eb46188128cd
   tag: v0.2.2
@@ -276,7 +283,6 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.3)
       pry (>= 0.9.10)
-    que (0.10.0)
     que-web (0.4.0)
       erubis
       que (~> 0.8)
@@ -442,7 +448,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry-rails
-  que
+  que!
   que-web
   quiet_assets (~> 1.1)
   rack-timeout

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ The tag `remote-authentication` has been created in order to mark the point at w
 with the Auth app is stripped out. Please checkout this tag in order to familiarise yourself with how this
 used to work.
 
+## Job Processing
+
+Laa Rota uses [Que](https://github.com/chanks/que) to process jobs asychronously.
+
+Que is configured not to process jobs in the same process as the web process, but in a seperate dedicated process.
+
+All jobs are enqueued to the 'default' queue.
+
+Run the que job processor with ```bundle exec que ./config/environment.rb```
+
+```
+usage: que [options] file/to/require ...
+    -w, --worker-count [COUNT]       Set number of workers in process (default: 4)
+    -i, --wake-interval [INTERVAL]   Set maximum interval between polls of the job queue (in seconds) (default: 0.1)
+    -l, --log-level [LEVEL]          Set level of Que's logger (debug, info, warn, error, fatal) (default: info)
+    -q, --queue-name [NAME]          Set the name of the queue to work jobs from (default: the default queue)
+    -v, --version                    Show Que version
+    -h, --help                       Show help text
+```
+
 ## Docker
 
 ### Building containers

--- a/config/initializers/devise_async.rb
+++ b/config/initializers/devise_async.rb
@@ -1,5 +1,5 @@
 Devise::Async.setup do |config|
   config.enabled = true
   config.backend = :que
-  config.queue   = ""
+  config.queue   = "default"
 end

--- a/config/initializers/que.rb
+++ b/config/initializers/que.rb
@@ -5,4 +5,5 @@ Rails.configuration.que.tap do |que|
   # into the primitive value `false` and blows up
   # calling `to_sym` :(
   que.mode = (Settings.que.mode || "off").to_sym
+  que.queue_name = "default"
 end


### PR DESCRIPTION
Update que to v0.11.0 to use the CLI to run processors and not the old rake task
Update README with info on que and how to run jobs
